### PR TITLE
Add pub visibility modifier for functions, structs, and enums (Phase 1 of Module System)

### DIFF
--- a/crates/rue-air/src/analysis_state.rs
+++ b/crates/rue-air/src/analysis_state.rs
@@ -3,12 +3,17 @@
 //! This module contains state that is mutated during function analysis.
 //! Each function can have its own `FunctionAnalysisState`, which is then
 //! merged after parallel analysis completes.
+//!
+//! # Array Type Handling (Phase 2 - ADR-0024)
+//!
+//! Array types are now handled by the shared `ArrayTypeRegistry` in `SemaContext`,
+//! which is thread-safe and handles deduplication automatically. Per-function
+//! array tracking has been removed - array types created during function analysis
+//! go directly to the shared registry.
 
 use std::collections::HashMap;
 
 use rue_error::CompileWarning;
-
-use crate::types::{ArrayTypeDef, ArrayTypeId, Type};
 
 /// Per-function mutable state during semantic analysis.
 ///
@@ -18,23 +23,21 @@ use crate::types::{ArrayTypeDef, ArrayTypeId, Type};
 ///
 /// # Contents
 ///
-/// - Array types created during analysis
 /// - String literals encountered
 /// - Warnings generated
+///
+/// # Note on Array Types
+///
+/// Array types are handled by the shared `ArrayTypeRegistry` in `SemaContext`.
+/// They are no longer tracked per-function as of ADR-0024 Phase 2.
 ///
 /// # Merging
 ///
 /// After parallel analysis, use `merge_into` to combine results:
-/// - Array types are deduplicated
 /// - Strings are deduplicated
 /// - Warnings are concatenated
 #[derive(Debug, Default)]
 pub struct FunctionAnalysisState {
-    /// Array types created during this function's analysis.
-    /// Key is (element_type, length), value is the ArrayTypeId assigned.
-    pub array_types: HashMap<(Type, u64), ArrayTypeId>,
-    /// Array type definitions in order of creation.
-    pub array_type_defs: Vec<ArrayTypeDef>,
     /// String table for deduplication.
     pub string_table: HashMap<String, u32>,
     /// String literals in order of creation.
@@ -64,22 +67,6 @@ impl FunctionAnalysisState {
         }
     }
 
-    /// Get or create an array type, returning its ID.
-    pub fn get_or_create_array_type(&mut self, element_type: Type, length: u64) -> ArrayTypeId {
-        let key = (element_type, length);
-        if let Some(&id) = self.array_types.get(&key) {
-            return id;
-        }
-
-        let id = ArrayTypeId(self.array_type_defs.len() as u32);
-        self.array_type_defs.push(ArrayTypeDef {
-            element_type,
-            length,
-        });
-        self.array_types.insert(key, id);
-        id
-    }
-
     /// Add a warning.
     pub fn add_warning(&mut self, warning: CompileWarning) {
         self.warnings.push(warning);
@@ -90,12 +77,13 @@ impl FunctionAnalysisState {
 ///
 /// This is the result of merging all `FunctionAnalysisState` instances
 /// after parallel analysis completes.
+///
+/// # Note on Array Types
+///
+/// Array types are handled by the shared `ArrayTypeRegistry` in `SemaContext`.
+/// They are no longer merged here as of ADR-0024 Phase 2.
 #[derive(Debug, Default)]
 pub struct MergedAnalysisState {
-    /// All array type definitions (deduplicated).
-    pub array_type_defs: Vec<ArrayTypeDef>,
-    /// Mapping from original (element_type, length) to final ArrayTypeId.
-    pub array_type_map: HashMap<(Type, u64), ArrayTypeId>,
     /// All string literals (deduplicated).
     pub strings: Vec<String>,
     /// Mapping from string content to final index.
@@ -112,29 +100,15 @@ impl MergedAnalysisState {
 
     /// Merge a function's analysis state into this merged state.
     ///
-    /// Returns a remapping for array type IDs so the function's AIR
+    /// Returns a remapping for string indices so the function's AIR
     /// can be updated with the final IDs.
+    ///
+    /// # Note
+    ///
+    /// Array type merging is no longer needed (ADR-0024 Phase 2).
+    /// Array types go directly to the shared `ArrayTypeRegistry`.
     pub fn merge_function_state(&mut self, state: FunctionAnalysisState) -> AnalysisStateRemapping {
-        let mut array_remap = HashMap::new();
         let mut string_remap = HashMap::new();
-
-        // Merge array types (deduplicate by (element_type, length))
-        for (key, old_id) in state.array_types {
-            let new_id = if let Some(&id) = self.array_type_map.get(&key) {
-                id
-            } else {
-                let id = ArrayTypeId(self.array_type_defs.len() as u32);
-                self.array_type_defs.push(ArrayTypeDef {
-                    element_type: key.0,
-                    length: key.1,
-                });
-                self.array_type_map.insert(key, id);
-                id
-            };
-            if old_id != new_id {
-                array_remap.insert(old_id, new_id);
-            }
-        }
 
         // Merge strings (deduplicate by content)
         for (content, old_id) in state.string_table {
@@ -154,10 +128,7 @@ impl MergedAnalysisState {
         // Merge warnings (no deduplication needed)
         self.warnings.extend(state.warnings);
 
-        AnalysisStateRemapping {
-            array_remap,
-            string_remap,
-        }
+        AnalysisStateRemapping { string_remap }
     }
 }
 
@@ -165,11 +136,13 @@ impl MergedAnalysisState {
 ///
 /// When function analysis states are merged, IDs may change due to
 /// deduplication. This struct provides the mapping from old to new IDs.
+///
+/// # Note
+///
+/// Array type remapping is no longer needed (ADR-0024 Phase 2).
+/// Array types use the shared `ArrayTypeRegistry` which handles deduplication.
 #[derive(Debug, Default)]
 pub struct AnalysisStateRemapping {
-    /// Mapping from old ArrayTypeId to new ArrayTypeId.
-    /// Only contains entries where the ID changed.
-    pub array_remap: HashMap<ArrayTypeId, ArrayTypeId>,
     /// Mapping from old string index to new string index.
     /// Only contains entries where the index changed.
     pub string_remap: HashMap<u32, u32>,
@@ -178,12 +151,7 @@ pub struct AnalysisStateRemapping {
 impl AnalysisStateRemapping {
     /// Check if any remapping is needed.
     pub fn is_empty(&self) -> bool {
-        self.array_remap.is_empty() && self.string_remap.is_empty()
-    }
-
-    /// Remap an array type ID if needed.
-    pub fn remap_array_type(&self, id: ArrayTypeId) -> ArrayTypeId {
-        self.array_remap.get(&id).copied().unwrap_or(id)
+        self.string_remap.is_empty()
     }
 
     /// Remap a string index if needed.

--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -957,6 +957,23 @@ impl<'a> ConstraintGenerator<'a> {
                     InferType::Concrete(Type::Error)
                 }
             }
+
+            // Comptime block: the type depends on whether evaluation succeeds at compile time.
+            // For type inference, we use a fresh type variable that can unify with
+            // whatever type is expected from the context (e.g., a let binding's type annotation).
+            // Similar to integer literals, comptime blocks can adapt to their context.
+            InstData::Comptime { expr } => {
+                // Generate constraints for the inner expression
+                let inner_info = self.generate(*expr, ctx);
+
+                // Use a fresh variable so comptime can unify with expected type from context.
+                // The actual evaluation happens in sema where we know the final type.
+                let var = self.fresh_var();
+                self.int_literal_vars.push(var);
+                // Add constraint that this var equals the inner expression's type
+                self.add_constraint(Constraint::equal(InferType::Var(var), inner_info.ty, span));
+                InferType::Var(var)
+            }
         };
 
         // Record the type for this expression

--- a/crates/rue-air/src/inst.rs
+++ b/crates/rue-air/src/inst.rs
@@ -14,7 +14,7 @@ use std::fmt;
 const _: () = assert!(std::mem::size_of::<AirInst>() <= 48);
 const _: () = assert!(std::mem::size_of::<AirInstData>() <= 32);
 
-use crate::types::{ArrayTypeId, StructId, Type};
+use crate::types::{StructId, Type};
 use lasso::{Key, Spur};
 use rue_span::Span;
 
@@ -611,44 +611,46 @@ pub enum AirInstData {
     },
 
     // Array operations
-    /// Create a new array with initialized elements
+    /// Create a new array with initialized elements.
+    /// The array type is stored in `AirInst.ty` as `Type::Array(...)`.
     ArrayInit {
-        /// The array type
-        array_type_id: ArrayTypeId,
         /// Start index into extra array for element refs
         elems_start: u32,
         /// Number of elements
         elems_len: u32,
     },
 
-    /// Load an element from an array
+    /// Load an element from an array.
+    /// The array type is stored in `AirInst.ty`.
     IndexGet {
         /// The array value
         base: AirRef,
-        /// The array type
-        array_type_id: ArrayTypeId,
+        /// The array type (for bounds checking and element size)
+        array_type: Type,
         /// Index expression
         index: AirRef,
     },
 
-    /// Store a value to an array element
+    /// Store a value to an array element.
+    /// The array type is stored in `AirInst.ty`.
     IndexSet {
         /// The array variable slot
         slot: u32,
-        /// The array type
-        array_type_id: ArrayTypeId,
+        /// The array type (for bounds checking and element size)
+        array_type: Type,
         /// Index expression
         index: AirRef,
         /// Value to store
         value: AirRef,
     },
 
-    /// Store a value to an array element of an inout parameter
+    /// Store a value to an array element of an inout parameter.
+    /// The array type is stored in `AirInst.ty`.
     ParamIndexSet {
         /// The parameter's ABI slot (relative to params, not locals)
         param_slot: u32,
-        /// The array type
-        array_type_id: ArrayTypeId,
+        /// The array type (for bounds checking and element size)
+        array_type: Type,
         /// Index expression
         index: AirRef,
         /// Value to store
@@ -893,11 +895,10 @@ impl fmt::Display for Air {
                     )?;
                 }
                 AirInstData::ArrayInit {
-                    array_type_id,
                     elems_start,
                     elems_len,
                 } => {
-                    write!(f, "array_init @{} [", array_type_id.0)?;
+                    write!(f, "array_init [")?;
                     for (i, elem) in self.get_air_refs(*elems_start, *elems_len).enumerate() {
                         if i > 0 {
                             write!(f, ", ")?;
@@ -908,33 +909,39 @@ impl fmt::Display for Air {
                 }
                 AirInstData::IndexGet {
                     base,
-                    array_type_id,
+                    array_type,
                     index,
                 } => {
-                    writeln!(f, "index_get {}(@{})[{}]", base, array_type_id.0, index)?;
+                    writeln!(f, "index_get {}({})[{}]", base, array_type.name(), index)?;
                 }
                 AirInstData::IndexSet {
                     slot,
-                    array_type_id,
+                    array_type,
                     index,
                     value,
                 } => {
                     writeln!(
                         f,
-                        "index_set ${}(@{})[{}] = {}",
-                        slot, array_type_id.0, index, value
+                        "index_set ${}({})[{}] = {}",
+                        slot,
+                        array_type.name(),
+                        index,
+                        value
                     )?;
                 }
                 AirInstData::ParamIndexSet {
                     param_slot,
-                    array_type_id,
+                    array_type,
                     index,
                     value,
                 } => {
                     writeln!(
                         f,
-                        "param_index_set param{}(@{})[{}] = {}",
-                        param_slot, array_type_id.0, index, value
+                        "param_index_set param{}({})[{}] = {}",
+                        param_slot,
+                        array_type.name(),
+                        index,
+                        value
                     )?;
                 }
                 AirInstData::EnumVariant {

--- a/crates/rue-air/src/intern_pool.rs
+++ b/crates/rue-air/src/intern_pool.rs
@@ -1,0 +1,1201 @@
+//! Type intern pool for efficient type representation.
+//!
+//! This module implements a unified type interning system inspired by Zig's `InternPool`.
+//! All types become 32-bit indices into a canonical pool, enabling:
+//!
+//! - O(1) type equality (u32 comparison)
+//! - Efficient memory usage
+//! - Clean parallel compilation (no per-function type merging)
+//! - Foundation for future generics
+//!
+//! # Architecture
+//!
+//! The `TypeInternPool` serves as a canonical repository for all composite types:
+//! - **Structs and enums** are nominal types (same name = same type)
+//! - **Arrays** are structural types (same element type + length = same type)
+//!
+//! Primitive types (i8-i64, u8-u64, bool, unit, never, error) are encoded directly
+//! in the `InternedType` index using reserved indices 0-15, requiring no pool lookup.
+//!
+//! # Migration Strategy (ADR-0024)
+//!
+//! This module is part of Phase 1 of the Type Intern Pool migration:
+//! - Phase 1: Introduce pool alongside existing system (this module)
+//! - Phase 2: Migrate array types to the pool
+//! - Phase 3: Migrate struct/enum IDs to pool indices
+//! - Phase 4: Unify Type representation to `InternedType(u32)`
+//!
+//! During Phase 1, the pool coexists with the existing `Type` enum, `StructId`,
+//! `EnumId`, and `ArrayTypeId`. The pool is populated during declaration collection
+//! but not yet used for type operations.
+//!
+//! # Thread Safety
+//!
+//! The pool uses `RwLock` for thread-safe access during parallel compilation:
+//! - Read lock for lookups (common case)
+//! - Write lock for insertions (rare, during declaration gathering)
+
+use std::collections::HashMap;
+use std::sync::RwLock;
+
+use lasso::Spur;
+
+use crate::types::{EnumDef, StructDef, Type};
+
+/// Interned type index - 32 bits, Copy, cheap comparison.
+///
+/// Reserved indices 0-15 are primitives (no lookup needed).
+/// Index 16+ are composite types stored in the pool.
+///
+/// # Primitive Encoding
+///
+/// The following indices are reserved for primitive types:
+/// - 0: i8
+/// - 1: i16
+/// - 2: i32
+/// - 3: i64
+/// - 4: u8
+/// - 5: u16
+/// - 6: u32
+/// - 7: u64
+/// - 8: bool
+/// - 9: unit
+/// - 10: never
+/// - 11: error
+/// - 12-15: reserved for future primitives
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub struct InternedType(u32);
+
+impl InternedType {
+    // Reserved indices for primitives
+    pub const I8: InternedType = InternedType(0);
+    pub const I16: InternedType = InternedType(1);
+    pub const I32: InternedType = InternedType(2);
+    pub const I64: InternedType = InternedType(3);
+    pub const U8: InternedType = InternedType(4);
+    pub const U16: InternedType = InternedType(5);
+    pub const U32: InternedType = InternedType(6);
+    pub const U64: InternedType = InternedType(7);
+    pub const BOOL: InternedType = InternedType(8);
+    pub const UNIT: InternedType = InternedType(9);
+    pub const NEVER: InternedType = InternedType(10);
+    pub const ERROR: InternedType = InternedType(11);
+
+    const PRIMITIVE_COUNT: u32 = 16;
+
+    /// Check if this is a primitive type (no pool lookup needed).
+    #[inline]
+    pub fn is_primitive(self) -> bool {
+        self.0 < Self::PRIMITIVE_COUNT
+    }
+
+    /// Get the raw index value.
+    #[inline]
+    pub fn index(self) -> u32 {
+        self.0
+    }
+
+    /// Create an InternedType from a raw index.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure the index is valid (either a primitive index 0-15,
+    /// or a composite index that exists in the pool).
+    #[inline]
+    pub fn from_raw(index: u32) -> Self {
+        InternedType(index)
+    }
+
+    /// Create an InternedType for a composite type from its pool index.
+    ///
+    /// The pool index is offset by `PRIMITIVE_COUNT` to produce the final index.
+    #[inline]
+    fn from_pool_index(pool_index: u32) -> Self {
+        InternedType(pool_index + Self::PRIMITIVE_COUNT)
+    }
+
+    /// Get the pool index for a composite type.
+    ///
+    /// Returns `None` for primitive types.
+    #[inline]
+    pub fn pool_index(self) -> Option<u32> {
+        if self.is_primitive() {
+            None
+        } else {
+            Some(self.0 - Self::PRIMITIVE_COUNT)
+        }
+    }
+}
+
+impl std::fmt::Debug for InternedType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.is_primitive() {
+            let name = match self.0 {
+                0 => "i8",
+                1 => "i16",
+                2 => "i32",
+                3 => "i64",
+                4 => "u8",
+                5 => "u16",
+                6 => "u32",
+                7 => "u64",
+                8 => "bool",
+                9 => "()",
+                10 => "!",
+                11 => "<error>",
+                _ => "<reserved>",
+            };
+            write!(f, "InternedType({name})")
+        } else {
+            write!(f, "InternedType(pool:{})", self.0 - Self::PRIMITIVE_COUNT)
+        }
+    }
+}
+
+/// Type data stored in the intern pool.
+///
+/// This is NOT Copy - it lives in the pool. You work with `InternedType` indices.
+///
+/// # Type Categories
+///
+/// - **Struct** and **Enum** are nominal types: identity comes from the name
+/// - **Array** is a structural type: identity comes from element type + length
+#[derive(Debug, Clone)]
+pub enum TypeData {
+    /// User-defined struct (nominal type).
+    ///
+    /// Two structs with the same fields but different names are different types.
+    Struct(StructData),
+
+    /// User-defined enum (nominal type).
+    ///
+    /// Two enums with the same variants but different names are different types.
+    Enum(EnumData),
+
+    /// Fixed-size array (structural type).
+    ///
+    /// Arrays with the same element type and length are the same type,
+    /// regardless of where they were defined.
+    Array { element: InternedType, len: u64 },
+}
+
+/// Data for a struct type in the intern pool.
+///
+/// During Phase 1, this mirrors the existing `StructDef` to verify correctness.
+/// In later phases, `StructDef` will be replaced by this.
+#[derive(Debug, Clone)]
+pub struct StructData {
+    /// The name symbol (interned string).
+    pub name: Spur,
+    /// Reference to the full struct definition.
+    /// During Phase 1, we keep a clone of the StructDef for verification.
+    /// In later phases, the pool will be the canonical source.
+    pub def: StructDef,
+}
+
+/// Data for an enum type in the intern pool.
+///
+/// During Phase 1, this mirrors the existing `EnumDef` to verify correctness.
+/// In later phases, `EnumDef` will be replaced by this.
+#[derive(Debug, Clone)]
+pub struct EnumData {
+    /// The name symbol (interned string).
+    pub name: Spur,
+    /// Reference to the full enum definition.
+    /// During Phase 1, we keep a clone of the EnumDef for verification.
+    /// In later phases, the pool will be the canonical source.
+    pub def: EnumDef,
+}
+
+/// Thread-safe intern pool for all composite types.
+///
+/// The pool is designed to be built during declaration gathering (sequential)
+/// and then queried during function body analysis (potentially parallel).
+///
+/// # Thread Safety
+///
+/// Uses `RwLock` for interior mutability:
+/// - Read lock for lookups (most common)
+/// - Write lock for insertions (only during declaration gathering)
+///
+/// # Usage
+///
+/// ```ignore
+/// let pool = TypeInternPool::new();
+///
+/// // Register nominal types (structs/enums)
+/// let (struct_type, is_new) = pool.register_struct(name_spur, struct_def);
+///
+/// // Intern structural types (arrays)
+/// let array_type = pool.intern_array(element_type, 10);
+///
+/// // Look up type data
+/// if let Some(data) = pool.try_get(some_type) {
+///     match data {
+///         TypeData::Struct(s) => println!("struct {}", s.def.name),
+///         TypeData::Enum(e) => println!("enum {}", e.def.name),
+///         TypeData::Array { element, len } => println!("array of {:?}; {}", element, len),
+///     }
+/// }
+/// ```
+#[derive(Debug)]
+pub struct TypeInternPool {
+    inner: RwLock<TypeInternPoolInner>,
+}
+
+#[derive(Debug)]
+struct TypeInternPoolInner {
+    /// All composite type data, indexed by (InternedType.0 - PRIMITIVE_COUNT).
+    types: Vec<TypeData>,
+
+    /// Structural type deduplication: (element, len) -> InternedType for arrays.
+    array_map: HashMap<(InternedType, u64), InternedType>,
+
+    /// Nominal type lookup: name -> InternedType for structs.
+    struct_by_name: HashMap<Spur, InternedType>,
+
+    /// Nominal type lookup: name -> InternedType for enums.
+    enum_by_name: HashMap<Spur, InternedType>,
+}
+
+impl TypeInternPool {
+    /// Create a new empty pool.
+    pub fn new() -> Self {
+        Self {
+            inner: RwLock::new(TypeInternPoolInner {
+                types: Vec::new(),
+                array_map: HashMap::new(),
+                struct_by_name: HashMap::new(),
+                enum_by_name: HashMap::new(),
+            }),
+        }
+    }
+
+    /// Register a new struct (nominal - no deduplication).
+    ///
+    /// Returns the `InternedType` and whether it was newly inserted.
+    /// If a struct with this name already exists, returns the existing type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the lock is poisoned.
+    pub fn register_struct(&self, name: Spur, def: StructDef) -> (InternedType, bool) {
+        // Fast path: check with read lock
+        {
+            let inner = self.inner.read().expect("TypeInternPool lock poisoned");
+            if let Some(&existing) = inner.struct_by_name.get(&name) {
+                return (existing, false);
+            }
+        }
+
+        // Slow path: acquire write lock
+        let mut inner = self.inner.write().expect("TypeInternPool lock poisoned");
+
+        // Double-check after acquiring write lock
+        if let Some(&existing) = inner.struct_by_name.get(&name) {
+            return (existing, false);
+        }
+
+        // Create new struct type
+        let pool_index = inner.types.len() as u32;
+        let interned = InternedType::from_pool_index(pool_index);
+
+        inner.types.push(TypeData::Struct(StructData { name, def }));
+        inner.struct_by_name.insert(name, interned);
+
+        (interned, true)
+    }
+
+    /// Register a new enum (nominal - no deduplication).
+    ///
+    /// Returns the `InternedType` and whether it was newly inserted.
+    /// If an enum with this name already exists, returns the existing type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the lock is poisoned.
+    pub fn register_enum(&self, name: Spur, def: EnumDef) -> (InternedType, bool) {
+        // Fast path: check with read lock
+        {
+            let inner = self.inner.read().expect("TypeInternPool lock poisoned");
+            if let Some(&existing) = inner.enum_by_name.get(&name) {
+                return (existing, false);
+            }
+        }
+
+        // Slow path: acquire write lock
+        let mut inner = self.inner.write().expect("TypeInternPool lock poisoned");
+
+        // Double-check after acquiring write lock
+        if let Some(&existing) = inner.enum_by_name.get(&name) {
+            return (existing, false);
+        }
+
+        // Create new enum type
+        let pool_index = inner.types.len() as u32;
+        let interned = InternedType::from_pool_index(pool_index);
+
+        inner.types.push(TypeData::Enum(EnumData { name, def }));
+        inner.enum_by_name.insert(name, interned);
+
+        (interned, true)
+    }
+
+    /// Intern an array type (structural - deduplicates).
+    ///
+    /// Returns the canonical `InternedType` for arrays with this element type and length.
+    /// If an identical array type already exists, returns the existing type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the lock is poisoned.
+    pub fn intern_array(&self, element: InternedType, len: u64) -> InternedType {
+        let key = (element, len);
+
+        // Fast path: check with read lock
+        {
+            let inner = self.inner.read().expect("TypeInternPool lock poisoned");
+            if let Some(&existing) = inner.array_map.get(&key) {
+                return existing;
+            }
+        }
+
+        // Slow path: acquire write lock
+        let mut inner = self.inner.write().expect("TypeInternPool lock poisoned");
+
+        // Double-check after acquiring write lock
+        if let Some(&existing) = inner.array_map.get(&key) {
+            return existing;
+        }
+
+        // Create new array type
+        let pool_index = inner.types.len() as u32;
+        let interned = InternedType::from_pool_index(pool_index);
+
+        inner.types.push(TypeData::Array { element, len });
+        inner.array_map.insert(key, interned);
+
+        interned
+    }
+
+    /// Look up a struct by name.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the lock is poisoned.
+    pub fn get_struct_by_name(&self, name: Spur) -> Option<InternedType> {
+        let inner = self.inner.read().expect("TypeInternPool lock poisoned");
+        inner.struct_by_name.get(&name).copied()
+    }
+
+    /// Look up an enum by name.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the lock is poisoned.
+    pub fn get_enum_by_name(&self, name: Spur) -> Option<InternedType> {
+        let inner = self.inner.read().expect("TypeInternPool lock poisoned");
+        inner.enum_by_name.get(&name).copied()
+    }
+
+    /// Look up an array type by element and length.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the lock is poisoned.
+    pub fn get_array(&self, element: InternedType, len: u64) -> Option<InternedType> {
+        let inner = self.inner.read().expect("TypeInternPool lock poisoned");
+        inner.array_map.get(&(element, len)).copied()
+    }
+
+    /// Get type data for a composite type.
+    ///
+    /// Returns `None` for primitive types (use `InternedType::is_primitive()` first).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the lock is poisoned or if the index is invalid.
+    pub fn get(&self, ty: InternedType) -> Option<TypeData> {
+        if ty.is_primitive() {
+            return None;
+        }
+
+        let pool_index = ty.pool_index().expect("non-primitive must have pool index");
+        let inner = self.inner.read().expect("TypeInternPool lock poisoned");
+        Some(inner.types[pool_index as usize].clone())
+    }
+
+    /// Check if this is a struct type.
+    pub fn is_struct(&self, ty: InternedType) -> bool {
+        if ty.is_primitive() {
+            return false;
+        }
+        matches!(self.get(ty), Some(TypeData::Struct(_)))
+    }
+
+    /// Check if this is an enum type.
+    pub fn is_enum(&self, ty: InternedType) -> bool {
+        if ty.is_primitive() {
+            return false;
+        }
+        matches!(self.get(ty), Some(TypeData::Enum(_)))
+    }
+
+    /// Check if this is an array type.
+    pub fn is_array(&self, ty: InternedType) -> bool {
+        if ty.is_primitive() {
+            return false;
+        }
+        matches!(self.get(ty), Some(TypeData::Array { .. }))
+    }
+
+    /// Get the struct definition if this is a struct type.
+    pub fn get_struct_def(&self, ty: InternedType) -> Option<StructDef> {
+        match self.get(ty)? {
+            TypeData::Struct(data) => Some(data.def),
+            _ => None,
+        }
+    }
+
+    /// Get the enum definition if this is an enum type.
+    pub fn get_enum_def(&self, ty: InternedType) -> Option<EnumDef> {
+        match self.get(ty)? {
+            TypeData::Enum(data) => Some(data.def),
+            _ => None,
+        }
+    }
+
+    /// Get array info (element type, length) if this is an array type.
+    pub fn get_array_info(&self, ty: InternedType) -> Option<(InternedType, u64)> {
+        match self.get(ty)? {
+            TypeData::Array { element, len } => Some((element, len)),
+            _ => None,
+        }
+    }
+
+    /// Get the number of composite types in the pool.
+    pub fn len(&self) -> usize {
+        let inner = self.inner.read().expect("TypeInternPool lock poisoned");
+        inner.types.len()
+    }
+
+    /// Check if the pool is empty (no composite types).
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Get statistics about the pool contents.
+    pub fn stats(&self) -> TypeInternPoolStats {
+        let inner = self.inner.read().expect("TypeInternPool lock poisoned");
+        let mut struct_count = 0;
+        let mut enum_count = 0;
+        let mut array_count = 0;
+
+        for data in &inner.types {
+            match data {
+                TypeData::Struct(_) => struct_count += 1,
+                TypeData::Enum(_) => enum_count += 1,
+                TypeData::Array { .. } => array_count += 1,
+            }
+        }
+
+        TypeInternPoolStats {
+            struct_count,
+            enum_count,
+            array_count,
+            total: inner.types.len(),
+        }
+    }
+
+    // ========================================================================
+    // Conversion helpers for migration (Phase 1)
+    // ========================================================================
+
+    /// Convert an old-style `Type` to an `InternedType`.
+    ///
+    /// This is a temporary helper for Phase 1 migration. It converts the
+    /// existing `Type` enum to the new interned representation.
+    ///
+    /// # Note
+    ///
+    /// For struct/enum types, the corresponding type must already be registered
+    /// in the pool. For array types, this returns an error since array interning
+    /// requires the pool to already have the element type interned.
+    pub fn type_to_interned(&self, ty: Type) -> Option<InternedType> {
+        match ty {
+            Type::I8 => Some(InternedType::I8),
+            Type::I16 => Some(InternedType::I16),
+            Type::I32 => Some(InternedType::I32),
+            Type::I64 => Some(InternedType::I64),
+            Type::U8 => Some(InternedType::U8),
+            Type::U16 => Some(InternedType::U16),
+            Type::U32 => Some(InternedType::U32),
+            Type::U64 => Some(InternedType::U64),
+            Type::Bool => Some(InternedType::BOOL),
+            Type::Unit => Some(InternedType::UNIT),
+            Type::Never => Some(InternedType::NEVER),
+            Type::Error => Some(InternedType::ERROR),
+            // Struct and enum require pool lookup by ID - we need the name
+            // to find the interned type. This conversion is not straightforward
+            // without additional context. Return None to indicate we can't convert.
+            Type::Struct(_) | Type::Enum(_) | Type::Array(_) => None,
+        }
+    }
+
+    /// Convert an `InternedType` back to the old-style `Type`.
+    ///
+    /// This is a temporary helper for Phase 1 migration to verify correctness.
+    /// Returns `None` for composite types since we need the old IDs.
+    pub fn interned_to_type(&self, ty: InternedType) -> Option<Type> {
+        if !ty.is_primitive() {
+            return None;
+        }
+
+        Some(match ty.0 {
+            0 => Type::I8,
+            1 => Type::I16,
+            2 => Type::I32,
+            3 => Type::I64,
+            4 => Type::U8,
+            5 => Type::U16,
+            6 => Type::U32,
+            7 => Type::U64,
+            8 => Type::Bool,
+            9 => Type::Unit,
+            10 => Type::Never,
+            11 => Type::Error,
+            _ => return None,
+        })
+    }
+}
+
+impl Default for TypeInternPool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Clone for TypeInternPool {
+    /// Clone the pool by copying all type data into a new pool.
+    ///
+    /// This is used when building `SemaContext` from `Sema`, as the context
+    /// needs its own copy of the pool for thread-safe sharing.
+    fn clone(&self) -> Self {
+        let inner = self.inner.read().expect("TypeInternPool lock poisoned");
+        Self {
+            inner: RwLock::new(TypeInternPoolInner {
+                types: inner.types.clone(),
+                array_map: inner.array_map.clone(),
+                struct_by_name: inner.struct_by_name.clone(),
+                enum_by_name: inner.enum_by_name.clone(),
+            }),
+        }
+    }
+}
+
+/// Statistics about the intern pool contents.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TypeInternPoolStats {
+    pub struct_count: usize,
+    pub enum_count: usize,
+    pub array_count: usize,
+    pub total: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lasso::ThreadedRodeo;
+
+    // ========================================================================
+    // InternedType tests
+    // ========================================================================
+
+    #[test]
+    fn test_interned_type_primitives() {
+        assert!(InternedType::I8.is_primitive());
+        assert!(InternedType::I16.is_primitive());
+        assert!(InternedType::I32.is_primitive());
+        assert!(InternedType::I64.is_primitive());
+        assert!(InternedType::U8.is_primitive());
+        assert!(InternedType::U16.is_primitive());
+        assert!(InternedType::U32.is_primitive());
+        assert!(InternedType::U64.is_primitive());
+        assert!(InternedType::BOOL.is_primitive());
+        assert!(InternedType::UNIT.is_primitive());
+        assert!(InternedType::NEVER.is_primitive());
+        assert!(InternedType::ERROR.is_primitive());
+    }
+
+    #[test]
+    fn test_interned_type_indices() {
+        assert_eq!(InternedType::I8.index(), 0);
+        assert_eq!(InternedType::I16.index(), 1);
+        assert_eq!(InternedType::I32.index(), 2);
+        assert_eq!(InternedType::I64.index(), 3);
+        assert_eq!(InternedType::U8.index(), 4);
+        assert_eq!(InternedType::BOOL.index(), 8);
+        assert_eq!(InternedType::UNIT.index(), 9);
+    }
+
+    #[test]
+    fn test_interned_type_pool_index() {
+        // Primitives don't have pool indices
+        assert_eq!(InternedType::I32.pool_index(), None);
+        assert_eq!(InternedType::BOOL.pool_index(), None);
+
+        // Composite types have pool indices
+        let composite = InternedType::from_pool_index(0);
+        assert_eq!(composite.pool_index(), Some(0));
+        assert!(!composite.is_primitive());
+
+        let composite2 = InternedType::from_pool_index(42);
+        assert_eq!(composite2.pool_index(), Some(42));
+    }
+
+    #[test]
+    fn test_interned_type_equality() {
+        assert_eq!(InternedType::I32, InternedType::I32);
+        assert_ne!(InternedType::I32, InternedType::I64);
+        assert_ne!(InternedType::I32, InternedType::from_pool_index(0));
+    }
+
+    #[test]
+    fn test_interned_type_debug() {
+        let i32_str = format!("{:?}", InternedType::I32);
+        assert!(i32_str.contains("i32"));
+
+        let composite_str = format!("{:?}", InternedType::from_pool_index(5));
+        assert!(composite_str.contains("pool:5"));
+    }
+
+    // ========================================================================
+    // TypeInternPool tests
+    // ========================================================================
+
+    #[test]
+    fn test_pool_new() {
+        let pool = TypeInternPool::new();
+        assert!(pool.is_empty());
+        assert_eq!(pool.len(), 0);
+    }
+
+    #[test]
+    fn test_pool_register_struct() {
+        let pool = TypeInternPool::new();
+        let interner = ThreadedRodeo::default();
+        let name = interner.get_or_intern("Point");
+
+        let def = StructDef {
+            name: "Point".to_string(),
+            fields: vec![],
+            is_copy: false,
+            is_handle: false,
+            is_linear: false,
+            destructor: None,
+            is_builtin: false,
+        };
+
+        let (ty, is_new) = pool.register_struct(name, def.clone());
+        assert!(is_new);
+        assert!(!ty.is_primitive());
+        assert_eq!(pool.len(), 1);
+
+        // Registering the same name returns the existing type
+        let (ty2, is_new2) = pool.register_struct(name, def);
+        assert!(!is_new2);
+        assert_eq!(ty, ty2);
+        assert_eq!(pool.len(), 1); // No new type added
+    }
+
+    #[test]
+    fn test_pool_register_enum() {
+        let pool = TypeInternPool::new();
+        let interner = ThreadedRodeo::default();
+        let name = interner.get_or_intern("Color");
+
+        let def = EnumDef {
+            name: "Color".to_string(),
+            variants: vec!["Red".to_string(), "Green".to_string(), "Blue".to_string()],
+        };
+
+        let (ty, is_new) = pool.register_enum(name, def.clone());
+        assert!(is_new);
+        assert!(!ty.is_primitive());
+        assert_eq!(pool.len(), 1);
+
+        // Registering the same name returns the existing type
+        let (ty2, is_new2) = pool.register_enum(name, def);
+        assert!(!is_new2);
+        assert_eq!(ty, ty2);
+    }
+
+    #[test]
+    fn test_pool_intern_array() {
+        let pool = TypeInternPool::new();
+
+        // Intern [i32; 5]
+        let arr1 = pool.intern_array(InternedType::I32, 5);
+        assert!(!arr1.is_primitive());
+        assert_eq!(pool.len(), 1);
+
+        // Interning the same array returns the same type
+        let arr2 = pool.intern_array(InternedType::I32, 5);
+        assert_eq!(arr1, arr2);
+        assert_eq!(pool.len(), 1);
+
+        // Different length is a different type
+        let arr3 = pool.intern_array(InternedType::I32, 10);
+        assert_ne!(arr1, arr3);
+        assert_eq!(pool.len(), 2);
+
+        // Different element type is a different type
+        let arr4 = pool.intern_array(InternedType::I64, 5);
+        assert_ne!(arr1, arr4);
+        assert_eq!(pool.len(), 3);
+    }
+
+    #[test]
+    fn test_pool_get_struct_by_name() {
+        let pool = TypeInternPool::new();
+        let interner = ThreadedRodeo::default();
+        let name = interner.get_or_intern("Point");
+
+        assert!(pool.get_struct_by_name(name).is_none());
+
+        let def = StructDef {
+            name: "Point".to_string(),
+            fields: vec![],
+            is_copy: false,
+            is_handle: false,
+            is_linear: false,
+            destructor: None,
+            is_builtin: false,
+        };
+
+        let (ty, _) = pool.register_struct(name, def);
+        assert_eq!(pool.get_struct_by_name(name), Some(ty));
+    }
+
+    #[test]
+    fn test_pool_get_enum_by_name() {
+        let pool = TypeInternPool::new();
+        let interner = ThreadedRodeo::default();
+        let name = interner.get_or_intern("Status");
+
+        assert!(pool.get_enum_by_name(name).is_none());
+
+        let def = EnumDef {
+            name: "Status".to_string(),
+            variants: vec!["Active".to_string(), "Inactive".to_string()],
+        };
+
+        let (ty, _) = pool.register_enum(name, def);
+        assert_eq!(pool.get_enum_by_name(name), Some(ty));
+    }
+
+    #[test]
+    fn test_pool_get_array() {
+        let pool = TypeInternPool::new();
+
+        assert!(pool.get_array(InternedType::I32, 5).is_none());
+
+        let arr = pool.intern_array(InternedType::I32, 5);
+        assert_eq!(pool.get_array(InternedType::I32, 5), Some(arr));
+        assert!(pool.get_array(InternedType::I32, 10).is_none());
+    }
+
+    #[test]
+    fn test_pool_get_type_data() {
+        let pool = TypeInternPool::new();
+        let interner = ThreadedRodeo::default();
+
+        // Primitive types return None
+        assert!(pool.get(InternedType::I32).is_none());
+
+        // Register a struct
+        let struct_name = interner.get_or_intern("Point");
+        let struct_def = StructDef {
+            name: "Point".to_string(),
+            fields: vec![],
+            is_copy: false,
+            is_handle: false,
+            is_linear: false,
+            destructor: None,
+            is_builtin: false,
+        };
+        let (struct_ty, _) = pool.register_struct(struct_name, struct_def);
+
+        // Get struct data
+        let data = pool.get(struct_ty).expect("should get struct data");
+        assert!(matches!(data, TypeData::Struct(_)));
+
+        // Intern an array
+        let arr_ty = pool.intern_array(InternedType::I32, 10);
+        let arr_data = pool.get(arr_ty).expect("should get array data");
+        match arr_data {
+            TypeData::Array { element, len } => {
+                assert_eq!(element, InternedType::I32);
+                assert_eq!(len, 10);
+            }
+            _ => panic!("expected array data"),
+        }
+    }
+
+    #[test]
+    fn test_pool_type_checks() {
+        let pool = TypeInternPool::new();
+        let interner = ThreadedRodeo::default();
+
+        let struct_name = interner.get_or_intern("Point");
+        let struct_def = StructDef {
+            name: "Point".to_string(),
+            fields: vec![],
+            is_copy: false,
+            is_handle: false,
+            is_linear: false,
+            destructor: None,
+            is_builtin: false,
+        };
+        let (struct_ty, _) = pool.register_struct(struct_name, struct_def);
+
+        let enum_name = interner.get_or_intern("Color");
+        let enum_def = EnumDef {
+            name: "Color".to_string(),
+            variants: vec!["Red".to_string()],
+        };
+        let (enum_ty, _) = pool.register_enum(enum_name, enum_def);
+
+        let array_ty = pool.intern_array(InternedType::I32, 5);
+
+        // Check is_struct
+        assert!(pool.is_struct(struct_ty));
+        assert!(!pool.is_struct(enum_ty));
+        assert!(!pool.is_struct(array_ty));
+        assert!(!pool.is_struct(InternedType::I32));
+
+        // Check is_enum
+        assert!(!pool.is_enum(struct_ty));
+        assert!(pool.is_enum(enum_ty));
+        assert!(!pool.is_enum(array_ty));
+        assert!(!pool.is_enum(InternedType::I32));
+
+        // Check is_array
+        assert!(!pool.is_array(struct_ty));
+        assert!(!pool.is_array(enum_ty));
+        assert!(pool.is_array(array_ty));
+        assert!(!pool.is_array(InternedType::I32));
+    }
+
+    #[test]
+    fn test_pool_get_struct_def() {
+        let pool = TypeInternPool::new();
+        let interner = ThreadedRodeo::default();
+
+        let name = interner.get_or_intern("Point");
+        let def = StructDef {
+            name: "Point".to_string(),
+            fields: vec![],
+            is_copy: true,
+            is_handle: false,
+            is_linear: false,
+            destructor: None,
+            is_builtin: false,
+        };
+        let (ty, _) = pool.register_struct(name, def.clone());
+
+        let retrieved = pool.get_struct_def(ty).expect("should get struct def");
+        assert_eq!(retrieved.name, def.name);
+        assert_eq!(retrieved.is_copy, def.is_copy);
+
+        // Non-struct returns None
+        let array_ty = pool.intern_array(InternedType::I32, 5);
+        assert!(pool.get_struct_def(array_ty).is_none());
+        assert!(pool.get_struct_def(InternedType::I32).is_none());
+    }
+
+    #[test]
+    fn test_pool_get_enum_def() {
+        let pool = TypeInternPool::new();
+        let interner = ThreadedRodeo::default();
+
+        let name = interner.get_or_intern("Status");
+        let def = EnumDef {
+            name: "Status".to_string(),
+            variants: vec!["A".to_string(), "B".to_string()],
+        };
+        let (ty, _) = pool.register_enum(name, def.clone());
+
+        let retrieved = pool.get_enum_def(ty).expect("should get enum def");
+        assert_eq!(retrieved.name, def.name);
+        assert_eq!(retrieved.variants.len(), 2);
+
+        // Non-enum returns None
+        let array_ty = pool.intern_array(InternedType::I32, 5);
+        assert!(pool.get_enum_def(array_ty).is_none());
+        assert!(pool.get_enum_def(InternedType::I32).is_none());
+    }
+
+    #[test]
+    fn test_pool_get_array_info() {
+        let pool = TypeInternPool::new();
+
+        let array_ty = pool.intern_array(InternedType::I64, 100);
+        let (element, len) = pool
+            .get_array_info(array_ty)
+            .expect("should get array info");
+        assert_eq!(element, InternedType::I64);
+        assert_eq!(len, 100);
+
+        // Non-array returns None
+        let interner = ThreadedRodeo::default();
+        let name = interner.get_or_intern("X");
+        let def = StructDef {
+            name: "X".to_string(),
+            fields: vec![],
+            is_copy: false,
+            is_handle: false,
+            is_linear: false,
+            destructor: None,
+            is_builtin: false,
+        };
+        let (struct_ty, _) = pool.register_struct(name, def);
+        assert!(pool.get_array_info(struct_ty).is_none());
+        assert!(pool.get_array_info(InternedType::I32).is_none());
+    }
+
+    #[test]
+    fn test_pool_stats() {
+        let pool = TypeInternPool::new();
+        let interner = ThreadedRodeo::default();
+
+        let stats = pool.stats();
+        assert_eq!(stats.struct_count, 0);
+        assert_eq!(stats.enum_count, 0);
+        assert_eq!(stats.array_count, 0);
+        assert_eq!(stats.total, 0);
+
+        // Add some types
+        let s1 = interner.get_or_intern("S1");
+        let s2 = interner.get_or_intern("S2");
+        let e1 = interner.get_or_intern("E1");
+
+        let def = StructDef {
+            name: "S1".to_string(),
+            fields: vec![],
+            is_copy: false,
+            is_handle: false,
+            is_linear: false,
+            destructor: None,
+            is_builtin: false,
+        };
+        pool.register_struct(s1, def.clone());
+        pool.register_struct(
+            s2,
+            StructDef {
+                name: "S2".to_string(),
+                ..def
+            },
+        );
+
+        pool.register_enum(
+            e1,
+            EnumDef {
+                name: "E1".to_string(),
+                variants: vec![],
+            },
+        );
+
+        pool.intern_array(InternedType::I32, 5);
+        pool.intern_array(InternedType::I32, 10);
+        pool.intern_array(InternedType::BOOL, 3);
+
+        let stats = pool.stats();
+        assert_eq!(stats.struct_count, 2);
+        assert_eq!(stats.enum_count, 1);
+        assert_eq!(stats.array_count, 3);
+        assert_eq!(stats.total, 6);
+    }
+
+    #[test]
+    fn test_pool_nested_arrays() {
+        let pool = TypeInternPool::new();
+
+        // Create [i32; 3]
+        let inner = pool.intern_array(InternedType::I32, 3);
+
+        // Create [[i32; 3]; 4]
+        let outer = pool.intern_array(inner, 4);
+
+        // Verify structure
+        let (outer_elem, outer_len) = pool.get_array_info(outer).expect("outer array info");
+        assert_eq!(outer_elem, inner);
+        assert_eq!(outer_len, 4);
+
+        let (inner_elem, inner_len) = pool.get_array_info(inner).expect("inner array info");
+        assert_eq!(inner_elem, InternedType::I32);
+        assert_eq!(inner_len, 3);
+    }
+
+    #[test]
+    fn test_pool_type_to_interned() {
+        let pool = TypeInternPool::new();
+
+        // Primitive types convert correctly
+        assert_eq!(pool.type_to_interned(Type::I8), Some(InternedType::I8));
+        assert_eq!(pool.type_to_interned(Type::I16), Some(InternedType::I16));
+        assert_eq!(pool.type_to_interned(Type::I32), Some(InternedType::I32));
+        assert_eq!(pool.type_to_interned(Type::I64), Some(InternedType::I64));
+        assert_eq!(pool.type_to_interned(Type::U8), Some(InternedType::U8));
+        assert_eq!(pool.type_to_interned(Type::U16), Some(InternedType::U16));
+        assert_eq!(pool.type_to_interned(Type::U32), Some(InternedType::U32));
+        assert_eq!(pool.type_to_interned(Type::U64), Some(InternedType::U64));
+        assert_eq!(pool.type_to_interned(Type::Bool), Some(InternedType::BOOL));
+        assert_eq!(pool.type_to_interned(Type::Unit), Some(InternedType::UNIT));
+        assert_eq!(
+            pool.type_to_interned(Type::Never),
+            Some(InternedType::NEVER)
+        );
+        assert_eq!(
+            pool.type_to_interned(Type::Error),
+            Some(InternedType::ERROR)
+        );
+
+        // Composite types return None (need name lookup)
+        assert!(
+            pool.type_to_interned(Type::Struct(crate::types::StructId(0)))
+                .is_none()
+        );
+        assert!(
+            pool.type_to_interned(Type::Enum(crate::types::EnumId(0)))
+                .is_none()
+        );
+        assert!(
+            pool.type_to_interned(Type::Array(crate::types::ArrayTypeId(0)))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_pool_interned_to_type() {
+        let pool = TypeInternPool::new();
+
+        // Primitive types convert back correctly
+        assert_eq!(pool.interned_to_type(InternedType::I8), Some(Type::I8));
+        assert_eq!(pool.interned_to_type(InternedType::I16), Some(Type::I16));
+        assert_eq!(pool.interned_to_type(InternedType::I32), Some(Type::I32));
+        assert_eq!(pool.interned_to_type(InternedType::I64), Some(Type::I64));
+        assert_eq!(pool.interned_to_type(InternedType::U8), Some(Type::U8));
+        assert_eq!(pool.interned_to_type(InternedType::U16), Some(Type::U16));
+        assert_eq!(pool.interned_to_type(InternedType::U32), Some(Type::U32));
+        assert_eq!(pool.interned_to_type(InternedType::U64), Some(Type::U64));
+        assert_eq!(pool.interned_to_type(InternedType::BOOL), Some(Type::Bool));
+        assert_eq!(pool.interned_to_type(InternedType::UNIT), Some(Type::Unit));
+        assert_eq!(
+            pool.interned_to_type(InternedType::NEVER),
+            Some(Type::Never)
+        );
+        assert_eq!(
+            pool.interned_to_type(InternedType::ERROR),
+            Some(Type::Error)
+        );
+
+        // Composite types return None
+        assert!(
+            pool.interned_to_type(InternedType::from_pool_index(0))
+                .is_none()
+        );
+    }
+
+    // ========================================================================
+    // Thread safety tests
+    // ========================================================================
+
+    #[test]
+    fn test_pool_concurrent_access() {
+        use std::sync::Arc;
+        use std::thread;
+
+        let pool = Arc::new(TypeInternPool::new());
+        let interner = Arc::new(ThreadedRodeo::default());
+
+        // Pre-register names for thread safety
+        let names: Vec<Spur> = (0..100)
+            .map(|i| interner.get_or_intern(format!("Type{}", i)))
+            .collect();
+
+        let handles: Vec<_> = (0..10)
+            .map(|thread_id| {
+                let pool = Arc::clone(&pool);
+                let names = names.clone();
+                thread::spawn(move || {
+                    // Each thread registers 10 types
+                    for i in 0..10 {
+                        let idx = thread_id * 10 + i;
+                        let name = names[idx];
+                        let def = StructDef {
+                            name: format!("Type{}", idx),
+                            fields: vec![],
+                            is_copy: false,
+                            is_handle: false,
+                            is_linear: false,
+                            destructor: None,
+                            is_builtin: false,
+                        };
+                        pool.register_struct(name, def);
+                    }
+                })
+            })
+            .collect();
+
+        for handle in handles {
+            handle.join().expect("thread panicked");
+        }
+
+        // All 100 types should be registered
+        assert_eq!(pool.len(), 100);
+
+        // Each name should map to a valid type
+        for name in &names {
+            assert!(pool.get_struct_by_name(*name).is_some());
+        }
+    }
+
+    #[test]
+    fn test_pool_concurrent_array_interning() {
+        use std::sync::Arc;
+        use std::thread;
+
+        let pool = Arc::new(TypeInternPool::new());
+
+        // Multiple threads try to intern the same array type
+        let handles: Vec<_> = (0..10)
+            .map(|_| {
+                let pool = Arc::clone(&pool);
+                thread::spawn(move || pool.intern_array(InternedType::I32, 42))
+            })
+            .collect();
+
+        let results: Vec<_> = handles
+            .into_iter()
+            .map(|h| h.join().expect("thread panicked"))
+            .collect();
+
+        // All threads should get the same type
+        let first = results[0];
+        for result in &results {
+            assert_eq!(*result, first);
+        }
+
+        // Only one array type should be in the pool
+        assert_eq!(pool.stats().array_count, 1);
+    }
+
+    // Compile-time assertion that TypeInternPool is Send + Sync
+    fn assert_send_sync<T: Send + Sync>() {}
+
+    #[test]
+    fn test_pool_is_send_sync() {
+        assert_send_sync::<TypeInternPool>();
+    }
+}

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -14,6 +14,7 @@ mod analysis_state;
 mod function_analyzer;
 mod inference;
 mod inst;
+mod intern_pool;
 mod scope;
 mod sema;
 mod sema_context;
@@ -31,6 +32,9 @@ pub use inference::{
 };
 pub use inst::{
     Air, AirArgMode, AirCallArg, AirInst, AirInstData, AirParamMode, AirPattern, AirRef,
+};
+pub use intern_pool::{
+    EnumData, InternedType, StructData, TypeData, TypeInternPool, TypeInternPoolStats,
 };
 pub use sema::{AnalyzedFunction, FunctionInfo, GatherOutput, MethodInfo, Sema, SemaOutput};
 // Note: FunctionInfo and MethodInfo are defined in sema and re-exported by sema_context.

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -299,6 +299,7 @@ fn analyze_all_function_bodies_sequential(sema: &mut Sema<'_>) -> MultiErrorResu
         array_types: std::mem::take(&mut sema.array_type_defs),
         strings: global_strings,
         warnings: all_warnings,
+        type_pool: sema.type_pool.clone(),
     })
 }
 
@@ -325,7 +326,13 @@ fn analyze_all_function_bodies_parallel(sema: Sema<'_>) -> MultiErrorResult<Sema
     let array_type_defs = ctx.array_registry.into_defs();
 
     // Merge results
-    merge_function_results(results, sema.struct_defs, sema.enum_defs, array_type_defs)
+    merge_function_results(
+        results,
+        sema.struct_defs,
+        sema.enum_defs,
+        array_type_defs,
+        sema.type_pool,
+    )
 }
 
 /// Collect all functions to be analyzed from the RIR.
@@ -1508,6 +1515,7 @@ fn merge_function_results(
     struct_defs: Vec<crate::types::StructDef>,
     enum_defs: Vec<crate::types::EnumDef>,
     array_type_defs: Vec<crate::types::ArrayTypeDef>,
+    type_pool: crate::intern_pool::TypeInternPool,
 ) -> MultiErrorResult<SemaOutput> {
     let mut errors = CompileErrors::new();
     let mut functions_with_strings: Vec<(AnalyzedFunction, Vec<String>)> = Vec::new();
@@ -1558,6 +1566,7 @@ fn merge_function_results(
         array_types: array_type_defs,
         strings: global_strings,
         warnings: all_warnings,
+        type_pool,
     })
 }
 

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -3076,7 +3076,7 @@ fn analyze_inst_for_projection_ctx(
             let air_ref = air.add_inst(AirInst {
                 data: AirInstData::IndexGet {
                     base: base_result.air_ref,
-                    array_type_id,
+                    array_type: base_type,
                     index: index_result.air_ref,
                 },
                 ty: elem_type,
@@ -3503,7 +3503,6 @@ fn analyze_array_init_ctx(
 
     let air_ref = air.add_inst(AirInst {
         data: AirInstData::ArrayInit {
-            array_type_id,
             elems_start,
             elems_len,
         },
@@ -3588,7 +3587,7 @@ fn analyze_index_get_ctx(
     let air_ref = air.add_inst(AirInst {
         data: AirInstData::IndexGet {
             base: base_result.air_ref,
-            array_type_id,
+            array_type: base_type,
             index: index_result.air_ref,
         },
         ty: elem_type,
@@ -3766,7 +3765,7 @@ fn analyze_index_set_ctx(
         air.add_inst(AirInst {
             data: AirInstData::ParamIndexSet {
                 param_slot: slot,
-                array_type_id,
+                array_type: base_type,
                 index: index_result.air_ref,
                 value: value_result.air_ref,
             },
@@ -3777,7 +3776,7 @@ fn analyze_index_set_ctx(
         air.add_inst(AirInst {
             data: AirInstData::IndexSet {
                 slot,
-                array_type_id,
+                array_type: base_type,
                 index: index_result.air_ref,
                 value: value_result.air_ref,
             },
@@ -5208,7 +5207,7 @@ impl<'a> Sema<'a> {
             let air_ref = air.add_inst(AirInst {
                 data: AirInstData::IndexGet {
                     base: base_result.air_ref,
-                    array_type_id,
+                    array_type: base_type,
                     index: index_result.air_ref,
                 },
                 ty: element_type,
@@ -5871,7 +5870,7 @@ impl<'a> Sema<'a> {
             air.add_inst(AirInst {
                 data: AirInstData::ParamIndexSet {
                     param_slot: slot,
-                    array_type_id,
+                    array_type: base_type,
                     index: index_result.air_ref,
                     value: value_result.air_ref,
                 },
@@ -5882,7 +5881,7 @@ impl<'a> Sema<'a> {
             air.add_inst(AirInst {
                 data: AirInstData::IndexSet {
                     slot,
-                    array_type_id,
+                    array_type: base_type,
                     index: index_result.air_ref,
                     value: value_result.air_ref,
                 },

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -43,6 +43,173 @@ use crate::scope::ScopedContext;
 use crate::sema_context::SemaContext;
 use crate::types::{EnumId, StructId, Type};
 
+/// Try to evaluate an RIR expression as a compile-time constant.
+///
+/// This is a standalone function that can be used from both `Sema` methods
+/// and parallel analysis code. It only requires a reference to the RIR.
+///
+/// Returns `Some(value)` if the expression can be fully evaluated at compile time,
+/// or `None` if evaluation requires runtime information (e.g., variable values,
+/// function calls) or would cause overflow/panic.
+fn try_evaluate_const_in_rir(rir: &rue_rir::Rir, inst_ref: InstRef) -> Option<ConstValue> {
+    let inst = rir.get(inst_ref);
+    match &inst.data {
+        // Integer literals
+        InstData::IntConst(value) => i64::try_from(*value).ok().map(ConstValue::Integer),
+
+        // Boolean literals
+        InstData::BoolConst(value) => Some(ConstValue::Bool(*value)),
+
+        // Unary negation: -expr
+        InstData::Neg { operand } => {
+            match try_evaluate_const_in_rir(rir, *operand)? {
+                ConstValue::Integer(n) => n.checked_neg().map(ConstValue::Integer),
+                ConstValue::Bool(_) => None, // Can't negate a boolean
+            }
+        }
+
+        // Logical NOT: !expr
+        InstData::Not { operand } => {
+            match try_evaluate_const_in_rir(rir, *operand)? {
+                ConstValue::Bool(b) => Some(ConstValue::Bool(!b)),
+                ConstValue::Integer(_) => None, // Can't logical-NOT an integer
+            }
+        }
+
+        // Binary arithmetic operations
+        InstData::Add { lhs, rhs } => {
+            let l = try_evaluate_const_in_rir(rir, *lhs)?.as_integer()?;
+            let r = try_evaluate_const_in_rir(rir, *rhs)?.as_integer()?;
+            l.checked_add(r).map(ConstValue::Integer)
+        }
+        InstData::Sub { lhs, rhs } => {
+            let l = try_evaluate_const_in_rir(rir, *lhs)?.as_integer()?;
+            let r = try_evaluate_const_in_rir(rir, *rhs)?.as_integer()?;
+            l.checked_sub(r).map(ConstValue::Integer)
+        }
+        InstData::Mul { lhs, rhs } => {
+            let l = try_evaluate_const_in_rir(rir, *lhs)?.as_integer()?;
+            let r = try_evaluate_const_in_rir(rir, *rhs)?.as_integer()?;
+            l.checked_mul(r).map(ConstValue::Integer)
+        }
+        InstData::Div { lhs, rhs } => {
+            let l = try_evaluate_const_in_rir(rir, *lhs)?.as_integer()?;
+            let r = try_evaluate_const_in_rir(rir, *rhs)?.as_integer()?;
+            if r == 0 {
+                None // Division by zero - defer to runtime
+            } else {
+                l.checked_div(r).map(ConstValue::Integer)
+            }
+        }
+        InstData::Mod { lhs, rhs } => {
+            let l = try_evaluate_const_in_rir(rir, *lhs)?.as_integer()?;
+            let r = try_evaluate_const_in_rir(rir, *rhs)?.as_integer()?;
+            if r == 0 {
+                None // Modulo by zero - defer to runtime
+            } else {
+                l.checked_rem(r).map(ConstValue::Integer)
+            }
+        }
+
+        // Comparison operations
+        InstData::Eq { lhs, rhs } => {
+            let l = try_evaluate_const_in_rir(rir, *lhs)?;
+            let r = try_evaluate_const_in_rir(rir, *rhs)?;
+            match (l, r) {
+                (ConstValue::Integer(a), ConstValue::Integer(b)) => Some(ConstValue::Bool(a == b)),
+                (ConstValue::Bool(a), ConstValue::Bool(b)) => Some(ConstValue::Bool(a == b)),
+                _ => None, // Mixed types
+            }
+        }
+        InstData::Ne { lhs, rhs } => {
+            let l = try_evaluate_const_in_rir(rir, *lhs)?;
+            let r = try_evaluate_const_in_rir(rir, *rhs)?;
+            match (l, r) {
+                (ConstValue::Integer(a), ConstValue::Integer(b)) => Some(ConstValue::Bool(a != b)),
+                (ConstValue::Bool(a), ConstValue::Bool(b)) => Some(ConstValue::Bool(a != b)),
+                _ => None,
+            }
+        }
+        InstData::Lt { lhs, rhs } => {
+            let l = try_evaluate_const_in_rir(rir, *lhs)?.as_integer()?;
+            let r = try_evaluate_const_in_rir(rir, *rhs)?.as_integer()?;
+            Some(ConstValue::Bool(l < r))
+        }
+        InstData::Gt { lhs, rhs } => {
+            let l = try_evaluate_const_in_rir(rir, *lhs)?.as_integer()?;
+            let r = try_evaluate_const_in_rir(rir, *rhs)?.as_integer()?;
+            Some(ConstValue::Bool(l > r))
+        }
+        InstData::Le { lhs, rhs } => {
+            let l = try_evaluate_const_in_rir(rir, *lhs)?.as_integer()?;
+            let r = try_evaluate_const_in_rir(rir, *rhs)?.as_integer()?;
+            Some(ConstValue::Bool(l <= r))
+        }
+        InstData::Ge { lhs, rhs } => {
+            let l = try_evaluate_const_in_rir(rir, *lhs)?.as_integer()?;
+            let r = try_evaluate_const_in_rir(rir, *rhs)?.as_integer()?;
+            Some(ConstValue::Bool(l >= r))
+        }
+
+        // Logical operations
+        InstData::And { lhs, rhs } => {
+            let l = try_evaluate_const_in_rir(rir, *lhs)?.as_bool()?;
+            let r = try_evaluate_const_in_rir(rir, *rhs)?.as_bool()?;
+            Some(ConstValue::Bool(l && r))
+        }
+        InstData::Or { lhs, rhs } => {
+            let l = try_evaluate_const_in_rir(rir, *lhs)?.as_bool()?;
+            let r = try_evaluate_const_in_rir(rir, *rhs)?.as_bool()?;
+            Some(ConstValue::Bool(l || r))
+        }
+
+        // Bitwise operations
+        InstData::BitAnd { lhs, rhs } => {
+            let l = try_evaluate_const_in_rir(rir, *lhs)?.as_integer()?;
+            let r = try_evaluate_const_in_rir(rir, *rhs)?.as_integer()?;
+            Some(ConstValue::Integer(l & r))
+        }
+        InstData::BitOr { lhs, rhs } => {
+            let l = try_evaluate_const_in_rir(rir, *lhs)?.as_integer()?;
+            let r = try_evaluate_const_in_rir(rir, *rhs)?.as_integer()?;
+            Some(ConstValue::Integer(l | r))
+        }
+        InstData::BitXor { lhs, rhs } => {
+            let l = try_evaluate_const_in_rir(rir, *lhs)?.as_integer()?;
+            let r = try_evaluate_const_in_rir(rir, *rhs)?.as_integer()?;
+            Some(ConstValue::Integer(l ^ r))
+        }
+        InstData::Shl { lhs, rhs } => {
+            let l = try_evaluate_const_in_rir(rir, *lhs)?.as_integer()?;
+            let r = try_evaluate_const_in_rir(rir, *rhs)?.as_integer()?;
+            // Only constant-fold small shift amounts to avoid type-width issues.
+            if r < 0 || r >= 8 {
+                return None;
+            }
+            Some(ConstValue::Integer(l << r))
+        }
+        InstData::Shr { lhs, rhs } => {
+            let l = try_evaluate_const_in_rir(rir, *lhs)?.as_integer()?;
+            let r = try_evaluate_const_in_rir(rir, *rhs)?.as_integer()?;
+            // Only constant-fold small shift amounts to avoid type-width issues.
+            if r < 0 || r >= 8 {
+                return None;
+            }
+            Some(ConstValue::Integer(l >> r))
+        }
+        InstData::BitNot { operand } => {
+            let n = try_evaluate_const_in_rir(rir, *operand)?.as_integer()?;
+            Some(ConstValue::Integer(!n))
+        }
+
+        // Comptime blocks: evaluate the inner expression
+        InstData::Comptime { expr } => try_evaluate_const_in_rir(rir, *expr),
+
+        // Everything else requires runtime evaluation
+        _ => None,
+    }
+}
+
 /// A description of a function to analyze.
 ///
 /// This is collected before parallel analysis so each function can be
@@ -1440,6 +1607,83 @@ fn analyze_inst_with_context(
                 ),
                 inst.span,
             ))
+        }
+
+        InstData::Comptime { expr } => {
+            // Gate the comptime feature
+            if !ctx.preview_features.contains(&PreviewFeature::Comptime) {
+                return Err(CompileError::new(
+                    ErrorKind::PreviewFeatureRequired {
+                        feature: PreviewFeature::Comptime,
+                        what: "comptime blocks".to_string(),
+                    },
+                    inst.span,
+                )
+                .with_help(format!(
+                    "use `--preview {}` to enable this feature ({})",
+                    PreviewFeature::Comptime.name(),
+                    PreviewFeature::Comptime.adr()
+                )));
+            }
+
+            // Try to evaluate the inner expression at compile time
+            match try_evaluate_const_in_rir(ctx.rir, *expr) {
+                Some(ConstValue::Integer(value)) => {
+                    // Get the expected type from HM inference
+                    let ty =
+                        get_resolved_type_ctx(analysis_ctx, inst_ref, inst.span, "comptime block")?;
+
+                    // Check if the value fits in the target type
+                    if value < 0 {
+                        // Can't represent negative values as u64 directly
+                        // For now, we only support non-negative integer values
+                        return Err(CompileError::new(
+                            ErrorKind::ComptimeEvaluationFailed {
+                                reason: "negative values not yet supported in comptime".to_string(),
+                            },
+                            inst.span,
+                        ));
+                    }
+
+                    let unsigned_value = value as u64;
+                    if !ty.literal_fits(unsigned_value) {
+                        return Err(CompileError::new(
+                            ErrorKind::LiteralOutOfRange {
+                                value: unsigned_value,
+                                ty: ty.name().to_string(),
+                            },
+                            inst.span,
+                        ));
+                    }
+
+                    let air_ref = air.add_inst(AirInst {
+                        data: AirInstData::Const(unsigned_value),
+                        ty,
+                        span: inst.span,
+                    });
+                    Ok(AnalysisResult::new(air_ref, ty))
+                }
+                Some(ConstValue::Bool(value)) => {
+                    let ty = Type::Bool;
+                    let air_ref = air.add_inst(AirInst {
+                        data: AirInstData::BoolConst(value),
+                        ty,
+                        span: inst.span,
+                    });
+                    Ok(AnalysisResult::new(air_ref, ty))
+                }
+                None => {
+                    // The expression couldn't be evaluated at compile time
+                    Err(CompileError::new(
+                        ErrorKind::ComptimeEvaluationFailed {
+                            reason:
+                                "expression contains values that cannot be known at compile time"
+                                    .to_string(),
+                        },
+                        inst.span,
+                    ))
+                }
+            }
         }
     }
 }
@@ -5148,6 +5392,67 @@ impl<'a> Sema<'a> {
             // Declaration no-ops (produce Unit in expression context)
             InstData::ImplDecl { .. } | InstData::DropFnDecl { .. } | InstData::FnDecl { .. } => {
                 self.analyze_decl_noop(air, inst_ref, ctx)
+            }
+
+            // Comptime block expression
+            InstData::Comptime { expr } => {
+                // Gate the comptime feature
+                self.require_preview(PreviewFeature::Comptime, "comptime blocks", inst.span)?;
+
+                // Try to evaluate the inner expression at compile time
+                match self.try_evaluate_const(*expr) {
+                    Some(ConstValue::Integer(value)) => {
+                        // Get the expected type from resolved types
+                        let ty =
+                            Self::get_resolved_type(ctx, inst_ref, inst.span, "comptime block")?;
+
+                        // Check if the value fits in the target type
+                        if value < 0 {
+                            return Err(CompileError::new(
+                                ErrorKind::ComptimeEvaluationFailed {
+                                    reason: "negative values not yet supported in comptime"
+                                        .to_string(),
+                                },
+                                inst.span,
+                            ));
+                        }
+
+                        let unsigned_value = value as u64;
+                        if !ty.literal_fits(unsigned_value) {
+                            return Err(CompileError::new(
+                                ErrorKind::LiteralOutOfRange {
+                                    value: unsigned_value,
+                                    ty: ty.name().to_string(),
+                                },
+                                inst.span,
+                            ));
+                        }
+
+                        let air_ref = air.add_inst(AirInst {
+                            data: AirInstData::Const(unsigned_value),
+                            ty,
+                            span: inst.span,
+                        });
+                        Ok(AnalysisResult::new(air_ref, ty))
+                    }
+                    Some(ConstValue::Bool(value)) => {
+                        let ty = Type::Bool;
+                        let air_ref = air.add_inst(AirInst {
+                            data: AirInstData::BoolConst(value),
+                            ty,
+                            span: inst.span,
+                        });
+                        Ok(AnalysisResult::new(air_ref, ty))
+                    }
+                    None => Err(CompileError::new(
+                        ErrorKind::ComptimeEvaluationFailed {
+                            reason:
+                                "expression contains values that cannot be known at compile time"
+                                    .to_string(),
+                        },
+                        inst.span,
+                    )),
+                }
             }
         }
     }

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -1693,7 +1693,6 @@ impl<'a> Sema<'a> {
 
         let air_ref = air.add_inst(AirInst {
             data: AirInstData::ArrayInit {
-                array_type_id,
                 elems_start,
                 elems_len,
             },
@@ -1764,7 +1763,7 @@ impl<'a> Sema<'a> {
         let air_ref = air.add_inst(AirInst {
             data: AirInstData::IndexGet {
                 base: base_result.air_ref,
-                array_type_id,
+                array_type: base_type,
                 index: index_result.air_ref,
             },
             ty: elem_type,

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -175,10 +175,20 @@ impl<'a> Sema<'a> {
         for (_, inst) in self.rir.iter() {
             match &inst.data {
                 InstData::EnumDecl {
+                    is_pub,
                     name,
                     variants_start,
                     variants_len,
                 } => {
+                    // pub visibility requires preview feature
+                    if *is_pub {
+                        self.require_preview(
+                            PreviewFeature::Modules,
+                            "pub visibility modifier",
+                            inst.span,
+                        )?;
+                    }
+
                     let enum_id = EnumId(self.enum_defs.len() as u32);
                     let enum_name = self.interner.resolve(&*name).to_string();
 
@@ -235,10 +245,20 @@ impl<'a> Sema<'a> {
                 InstData::StructDecl {
                     directives_start,
                     directives_len,
+                    is_pub,
                     is_linear,
                     name,
                     ..
                 } => {
+                    // pub visibility requires preview feature
+                    if *is_pub {
+                        self.require_preview(
+                            PreviewFeature::Modules,
+                            "pub visibility modifier",
+                            inst.span,
+                        )?;
+                    }
+
                     let struct_id = StructId(self.struct_defs.len() as u32);
                     let struct_name = self.interner.resolve(&*name).to_string();
 
@@ -424,12 +444,22 @@ impl<'a> Sema<'a> {
                 }
 
                 InstData::FnDecl {
+                    is_pub,
                     name,
                     params_start,
                     params_len,
                     return_type,
                     ..
                 } => {
+                    // pub visibility requires preview feature
+                    if *is_pub {
+                        self.require_preview(
+                            PreviewFeature::Modules,
+                            "pub visibility modifier",
+                            inst.span,
+                        )?;
+                    }
+
                     self.collect_function_signature(
                         *name,
                         *params_start,

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -312,7 +312,38 @@ impl<'a> Sema<'a> {
     /// body analysis.
     pub(crate) fn resolve_declarations(&mut self) -> CompileResult<()> {
         self.resolve_struct_fields()?;
-        self.resolve_remaining_declarations()
+        self.resolve_remaining_declarations()?;
+
+        // Populate the type intern pool (ADR-0024 Phase 1).
+        // This runs after all type definitions are complete so we have
+        // full struct/enum definitions with resolved fields and variants.
+        self.populate_type_pool();
+
+        Ok(())
+    }
+
+    /// Populate the type intern pool with all registered types.
+    ///
+    /// This is part of ADR-0024 Phase 1: the pool coexists with the existing
+    /// type registries and is populated after declarations are complete.
+    /// The pool can be used for verification but is not yet the canonical
+    /// source for type information.
+    pub(crate) fn populate_type_pool(&mut self) {
+        // Register all structs in the pool
+        for (name_spur, &struct_id) in &self.structs {
+            let def = &self.struct_defs[struct_id.0 as usize];
+            self.type_pool.register_struct(*name_spur, def.clone());
+        }
+
+        // Register all enums in the pool
+        for (name_spur, &enum_id) in &self.enums {
+            let def = &self.enum_defs[enum_id.0 as usize];
+            self.type_pool.register_enum(*name_spur, def.clone());
+        }
+
+        // Note: Array types are not populated here during Phase 1.
+        // They are created on-demand during function body analysis via the
+        // ArrayTypeRegistry, and will be migrated to the pool in Phase 2.
     }
 
     /// Resolve struct field types. Must run before @copy validation.

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -36,6 +36,7 @@ use lasso::{Spur, ThreadedRodeo};
 use rue_error::{CompileErrors, MultiErrorResult, PreviewFeatures};
 use rue_rir::Rir;
 
+use crate::intern_pool::TypeInternPool;
 use crate::sema_context::{
     ArrayTypeRegistry, InferenceContext as SemaContextInferenceContext, SemaContext,
 };
@@ -102,6 +103,8 @@ pub struct GatherOutput<'a> {
     pub preview_features: PreviewFeatures,
     /// StructId of the synthetic String type.
     pub builtin_string_id: Option<StructId>,
+    /// Type intern pool (ADR-0024 Phase 1).
+    pub type_pool: TypeInternPool,
 }
 
 impl<'a> GatherOutput<'a> {
@@ -124,6 +127,7 @@ impl<'a> GatherOutput<'a> {
             preview_features: self.preview_features,
             builtin_string_id: self.builtin_string_id,
             known: KnownSymbols::new(self.interner),
+            type_pool: self.type_pool,
         }
     }
 
@@ -171,6 +175,8 @@ pub struct SemaOutput {
     pub strings: Vec<String>,
     /// Warnings collected during analysis.
     pub warnings: Vec<rue_error::CompileWarning>,
+    /// Type intern pool (Phase 1: coexists with existing type system).
+    pub type_pool: TypeInternPool,
 }
 
 /// Pre-computed type information for constraint generation.
@@ -256,6 +262,12 @@ pub struct Sema<'a> {
     pub(crate) builtin_string_id: Option<StructId>,
     /// Pre-interned known symbols for fast comparison.
     pub(crate) known: KnownSymbols,
+    /// Type intern pool for unified type representation (ADR-0024 Phase 1).
+    ///
+    /// During Phase 1, the pool coexists with the existing type registries.
+    /// It is populated during declaration collection but not yet used for
+    /// type operations. Later phases will migrate to using the pool exclusively.
+    pub(crate) type_pool: TypeInternPool,
 }
 
 impl<'a> Sema<'a> {
@@ -279,6 +291,7 @@ impl<'a> Sema<'a> {
             preview_features,
             builtin_string_id: None,
             known: KnownSymbols::new(interner),
+            type_pool: TypeInternPool::new(),
         }
     }
 
@@ -391,6 +404,7 @@ impl<'a> Sema<'a> {
             methods: self.methods,
             preview_features: self.preview_features,
             builtin_string_id: self.builtin_string_id,
+            type_pool: self.type_pool,
         };
 
         Ok((type_ctx, output))
@@ -444,6 +458,7 @@ impl<'a> Sema<'a> {
             builtin_string_id: self.builtin_string_id,
             inference_ctx,
             known: KnownSymbols::new(self.interner),
+            type_pool: self.type_pool.clone(),
         }
     }
 

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -812,4 +812,229 @@ mod tests {
 
         assert!(result.is_err());
     }
+
+    // ========================================================================
+    // Type Intern Pool tests (ADR-0024 Phase 1)
+    //
+    // These tests verify that the TypeInternPool is correctly populated during
+    // declaration collection and that its contents match the existing type
+    // registries (struct_defs, enum_defs).
+    // ========================================================================
+
+    /// Helper to gather declarations and return the Sema state for testing.
+    fn gather_declarations_for_testing(source: &str) -> Sema<'static> {
+        // We need to leak the interner for the static lifetime
+        let lexer = Lexer::new(source);
+        let (tokens, interner) = lexer.tokenize().unwrap();
+        let parser = Parser::new(tokens, interner);
+        let (ast, mut interner) = parser.parse().unwrap();
+
+        let astgen = AstGen::new(&ast, &mut interner);
+        let rir = astgen.generate();
+
+        // Leak both to get 'static lifetime for testing
+        let rir = Box::leak(Box::new(rir));
+        let interner = Box::leak(Box::new(interner));
+
+        let mut sema = Sema::new(rir, interner, PreviewFeatures::new());
+        sema.inject_builtin_types();
+        sema.register_type_names().unwrap();
+        sema.resolve_declarations().unwrap();
+        sema
+    }
+
+    #[test]
+    fn test_type_pool_populated_with_builtin_string() {
+        // The String type should be in the pool after builtin injection
+        let sema = gather_declarations_for_testing("fn main() -> i32 { 0 }");
+
+        let string_name = sema.interner.get("String").unwrap();
+        let pool_string = sema.type_pool.get_struct_by_name(string_name);
+
+        assert!(pool_string.is_some(), "String should be in the type pool");
+
+        // Verify the pool and existing registry agree
+        let registry_string = sema.structs.get(&string_name);
+        assert!(
+            registry_string.is_some(),
+            "String should be in struct registry"
+        );
+
+        // Check that the definitions match
+        let pool_def = sema.type_pool.get_struct_def(pool_string.unwrap()).unwrap();
+        let registry_def = &sema.struct_defs[registry_string.unwrap().0 as usize];
+
+        assert_eq!(pool_def.name, registry_def.name);
+        assert_eq!(pool_def.is_builtin, registry_def.is_builtin);
+        assert!(pool_def.is_builtin, "String should be marked as builtin");
+    }
+
+    #[test]
+    fn test_type_pool_populated_with_user_struct() {
+        let sema = gather_declarations_for_testing(
+            "struct Point { x: i32, y: i32 }
+             fn main() -> i32 { 0 }",
+        );
+
+        let point_name = sema.interner.get("Point").unwrap();
+
+        // Check the pool has the struct
+        let pool_point = sema.type_pool.get_struct_by_name(point_name);
+        assert!(pool_point.is_some(), "Point should be in the type pool");
+
+        // Verify pool and registry agree
+        let registry_point = sema.structs.get(&point_name);
+        assert!(
+            registry_point.is_some(),
+            "Point should be in struct registry"
+        );
+
+        // Check that definitions match
+        let pool_def = sema.type_pool.get_struct_def(pool_point.unwrap()).unwrap();
+        let registry_def = &sema.struct_defs[registry_point.unwrap().0 as usize];
+
+        assert_eq!(pool_def.name, registry_def.name);
+        assert_eq!(pool_def.fields.len(), registry_def.fields.len());
+        assert_eq!(pool_def.fields.len(), 2);
+        assert_eq!(pool_def.fields[0].name, "x");
+        assert_eq!(pool_def.fields[1].name, "y");
+        assert_eq!(pool_def.is_copy, registry_def.is_copy);
+        assert!(
+            !pool_def.is_builtin,
+            "Point should not be marked as builtin"
+        );
+    }
+
+    #[test]
+    fn test_type_pool_populated_with_enum() {
+        let sema = gather_declarations_for_testing(
+            "enum Color { Red, Green, Blue }
+             fn main() -> i32 { 0 }",
+        );
+
+        let color_name = sema.interner.get("Color").unwrap();
+
+        // Check the pool has the enum
+        let pool_color = sema.type_pool.get_enum_by_name(color_name);
+        assert!(pool_color.is_some(), "Color should be in the type pool");
+
+        // Verify pool and registry agree
+        let registry_color = sema.enums.get(&color_name);
+        assert!(registry_color.is_some(), "Color should be in enum registry");
+
+        // Check that definitions match
+        let pool_def = sema.type_pool.get_enum_def(pool_color.unwrap()).unwrap();
+        let registry_def = &sema.enum_defs[registry_color.unwrap().0 as usize];
+
+        assert_eq!(pool_def.name, registry_def.name);
+        assert_eq!(pool_def.variants.len(), registry_def.variants.len());
+        assert_eq!(pool_def.variants.len(), 3);
+        assert_eq!(pool_def.variants[0], "Red");
+        assert_eq!(pool_def.variants[1], "Green");
+        assert_eq!(pool_def.variants[2], "Blue");
+    }
+
+    #[test]
+    fn test_type_pool_copy_struct() {
+        let sema = gather_declarations_for_testing(
+            "@copy
+             struct Data { value: i32 }
+             fn main() -> i32 { 0 }",
+        );
+
+        let data_name = sema.interner.get("Data").unwrap();
+        let pool_data = sema.type_pool.get_struct_by_name(data_name).unwrap();
+        let pool_def = sema.type_pool.get_struct_def(pool_data).unwrap();
+
+        assert!(pool_def.is_copy, "Data should be marked as @copy");
+    }
+
+    #[test]
+    fn test_type_pool_stats() {
+        let sema = gather_declarations_for_testing(
+            "struct A {}
+             struct B {}
+             enum E { X }
+             fn main() -> i32 { 0 }",
+        );
+
+        let stats = sema.type_pool.stats();
+
+        // 3 structs: String (builtin) + A + B
+        assert_eq!(stats.struct_count, 3);
+        // 1 enum: E
+        assert_eq!(stats.enum_count, 1);
+        // No arrays in Phase 1
+        assert_eq!(stats.array_count, 0);
+        // Total: 4 composite types
+        assert_eq!(stats.total, 4);
+    }
+
+    #[test]
+    fn test_type_pool_all_registries_match() {
+        // Test with multiple types to verify complete consistency
+        let sema = gather_declarations_for_testing(
+            "struct Point { x: i32, y: i32 }
+             struct Empty {}
+             @copy struct Value { v: bool }
+             enum Status { Ok, Error }
+             enum Direction { Up, Down, Left, Right }
+             fn main() -> i32 { 0 }",
+        );
+
+        // Verify all structs in registry are in pool
+        for (name_spur, &struct_id) in &sema.structs {
+            let registry_def = &sema.struct_defs[struct_id.0 as usize];
+            let pool_type = sema.type_pool.get_struct_by_name(*name_spur);
+
+            assert!(
+                pool_type.is_some(),
+                "Struct '{}' should be in pool",
+                registry_def.name
+            );
+
+            let pool_def = sema.type_pool.get_struct_def(pool_type.unwrap()).unwrap();
+            assert_eq!(
+                pool_def.name, registry_def.name,
+                "Struct names should match"
+            );
+            assert_eq!(
+                pool_def.fields.len(),
+                registry_def.fields.len(),
+                "Field counts should match for {}",
+                registry_def.name
+            );
+            assert_eq!(
+                pool_def.is_copy, registry_def.is_copy,
+                "is_copy should match for {}",
+                registry_def.name
+            );
+        }
+
+        // Verify all enums in registry are in pool
+        for (name_spur, &enum_id) in &sema.enums {
+            let registry_def = &sema.enum_defs[enum_id.0 as usize];
+            let pool_type = sema.type_pool.get_enum_by_name(*name_spur);
+
+            assert!(
+                pool_type.is_some(),
+                "Enum '{}' should be in pool",
+                registry_def.name
+            );
+
+            let pool_def = sema.type_pool.get_enum_def(pool_type.unwrap()).unwrap();
+            assert_eq!(pool_def.name, registry_def.name, "Enum names should match");
+            assert_eq!(
+                pool_def.variants.len(),
+                registry_def.variants.len(),
+                "Variant counts should match for {}",
+                registry_def.name
+            );
+        }
+
+        // Verify counts match
+        let stats = sema.type_pool.stats();
+        assert_eq!(stats.struct_count, sema.struct_defs.len());
+        assert_eq!(stats.enum_count, sema.enum_defs.len());
+    }
 }

--- a/crates/rue-air/src/sema_context.rs
+++ b/crates/rue-air/src/sema_context.rs
@@ -36,6 +36,7 @@ use rue_error::PreviewFeatures;
 use rue_rir::Rir;
 
 use crate::inference::{FunctionSig, InferType, MethodSig};
+use crate::intern_pool::TypeInternPool;
 // Import FunctionInfo, MethodInfo, and KnownSymbols from sema module to avoid duplication.
 // FunctionInfo and MethodInfo are the canonical definitions; we re-export them for convenience.
 pub use crate::sema::{FunctionInfo, KnownSymbols, MethodInfo};
@@ -224,11 +225,19 @@ pub struct SemaContext<'a> {
     pub inference_ctx: InferenceContext,
     /// Pre-interned known symbols for fast comparison.
     pub known: KnownSymbols,
+    /// Type intern pool for unified type representation (ADR-0024 Phase 1).
+    ///
+    /// During Phase 1, the pool coexists with the existing type registries.
+    /// It can be used for lookups but the canonical type representation
+    /// remains the old `Type` enum. Later phases will migrate to using
+    /// the pool exclusively.
+    pub type_pool: TypeInternPool,
 }
 
 // SAFETY: SemaContext is Send + Sync because:
 // - Immutable fields (struct_defs, enum_defs, structs, enums, etc.) are trivially thread-safe
 // - ArrayTypeRegistry uses RwLock for interior mutability
+// - TypeInternPool uses RwLock for interior mutability
 // - References to RIR and ThreadedRodeo are shared immutably
 // - References to functions/methods HashMaps are shared immutably (read-only after declaration gathering)
 // - ThreadedRodeo is designed to be thread-safe

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -1451,7 +1451,6 @@ impl<'a> CfgBuilder<'a> {
             }
 
             AirInstData::ArrayInit {
-                array_type_id,
                 elems_start,
                 elems_len,
             } => {
@@ -1466,7 +1465,6 @@ impl<'a> CfgBuilder<'a> {
                 let (elements_start, elements_len) = self.cfg.push_extra(element_vals);
                 let value = self.emit(
                     CfgInstData::ArrayInit {
-                        array_type_id: *array_type_id,
                         elements_start,
                         elements_len,
                     },
@@ -1482,7 +1480,7 @@ impl<'a> CfgBuilder<'a> {
 
             AirInstData::IndexGet {
                 base,
-                array_type_id,
+                array_type,
                 index,
             } => {
                 let Some(base_val) = self.lower_value(*base) else {
@@ -1494,7 +1492,7 @@ impl<'a> CfgBuilder<'a> {
                 let value = self.emit(
                     CfgInstData::IndexGet {
                         base: base_val,
-                        array_type_id: *array_type_id,
+                        array_type: *array_type,
                         index: index_val,
                     },
                     ty,
@@ -1509,7 +1507,7 @@ impl<'a> CfgBuilder<'a> {
 
             AirInstData::IndexSet {
                 slot,
-                array_type_id,
+                array_type,
                 index,
                 value,
             } => {
@@ -1522,7 +1520,7 @@ impl<'a> CfgBuilder<'a> {
                 self.emit(
                     CfgInstData::IndexSet {
                         slot: *slot,
-                        array_type_id: *array_type_id,
+                        array_type: *array_type,
                         index: index_val,
                         value: val,
                     },
@@ -1537,7 +1535,7 @@ impl<'a> CfgBuilder<'a> {
 
             AirInstData::ParamIndexSet {
                 param_slot,
-                array_type_id,
+                array_type,
                 index,
                 value,
             } => {
@@ -1550,7 +1548,7 @@ impl<'a> CfgBuilder<'a> {
                 self.emit(
                     CfgInstData::ParamIndexSet {
                         param_slot: *param_slot,
-                        array_type_id: *array_type_id,
+                        array_type: *array_type,
                         index: index_val,
                         value: val,
                     },

--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -16,7 +16,7 @@ const _: () = assert!(std::mem::size_of::<CfgInst>() <= 48);
 const _: () = assert!(std::mem::size_of::<CfgInstData>() <= 32);
 
 use lasso::{Key, Spur};
-use rue_air::{ArrayTypeId, EnumId, StructId, Type};
+use rue_air::{EnumId, StructId, Type};
 use rue_span::Span;
 
 /// A basic block identifier.
@@ -245,21 +245,26 @@ pub enum CfgInstData {
     // Array operations
     /// Array initialization. Element values are stored in the Cfg's extra array.
     /// Use `Cfg::get_extra(elements_start, elements_len)` to retrieve them.
+    /// The array type is stored in `CfgInst.ty`.
     ArrayInit {
-        array_type_id: ArrayTypeId,
         /// Start index into Cfg's extra array
         elements_start: u32,
         /// Number of elements
         elements_len: u32,
     },
+    /// Load an element from an array.
+    /// The result type is the element type.
     IndexGet {
         base: CfgValue,
-        array_type_id: ArrayTypeId,
+        /// The array type (for bounds checking and element size)
+        array_type: Type,
         index: CfgValue,
     },
+    /// Store a value to an array element.
     IndexSet {
         slot: u32,
-        array_type_id: ArrayTypeId,
+        /// The array type (for bounds checking and element size)
+        array_type: Type,
         index: CfgValue,
         value: CfgValue,
     },
@@ -267,8 +272,8 @@ pub enum CfgInstData {
     ParamIndexSet {
         /// The parameter's ABI slot (relative to params, not locals)
         param_slot: u32,
-        /// The array type
-        array_type_id: ArrayTypeId,
+        /// The array type (for bounds checking and element size)
+        array_type: Type,
         /// Index expression
         index: CfgValue,
         /// Value to store
@@ -978,11 +983,10 @@ impl Cfg {
                 )
             }
             CfgInstData::ArrayInit {
-                array_type_id,
                 elements_start,
                 elements_len,
             } => {
-                write!(f, "array_init @{} [", array_type_id.0)?;
+                write!(f, "array_init [")?;
                 let elements = self.get_extra(*elements_start, *elements_len);
                 for (i, elem) in elements.iter().enumerate() {
                     if i > 0 {
@@ -994,33 +998,39 @@ impl Cfg {
             }
             CfgInstData::IndexGet {
                 base,
-                array_type_id,
+                array_type,
                 index,
             } => {
-                write!(f, "index_get {}(@{})[{}]", base, array_type_id.0, index)
+                write!(f, "index_get {}({})[{}]", base, array_type.name(), index)
             }
             CfgInstData::IndexSet {
                 slot,
-                array_type_id,
+                array_type,
                 index,
                 value,
             } => {
                 write!(
                     f,
-                    "index_set ${}(@{})[{}] = {}",
-                    slot, array_type_id.0, index, value
+                    "index_set ${}({})[{}] = {}",
+                    slot,
+                    array_type.name(),
+                    index,
+                    value
                 )
             }
             CfgInstData::ParamIndexSet {
                 param_slot,
-                array_type_id,
+                array_type,
                 index,
                 value,
             } => {
                 write!(
                     f,
-                    "param_index_set %{}(@{})[{}] = {}",
-                    param_slot, array_type_id.0, index, value
+                    "param_index_set %{}({})[{}] = {}",
+                    param_slot,
+                    array_type.name(),
+                    index,
+                    value
                 )
             }
             CfgInstData::EnumVariant {

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -6,7 +6,7 @@
 use std::collections::HashMap;
 
 use lasso::ThreadedRodeo;
-use rue_air::{ArrayTypeDef, ArrayTypeId};
+use rue_air::ArrayTypeDef;
 use rue_cfg::{
     BasicBlock, BlockId, Cfg, CfgInstData, CfgValue, StructDef, StructId, Terminator, Type,
 };
@@ -115,21 +115,13 @@ impl<'a> CfgLower<'a> {
     }
 
     /// Get the length of an array type.
-    fn array_length(&self, array_type_id: ArrayTypeId) -> u64 {
-        debug_assert!(
-            (array_type_id.0 as usize) < self.array_types.len(),
-            "invalid array type ID: {:?}",
-            array_type_id
-        );
-        self.array_types
-            .get(array_type_id.0 as usize)
-            .map(|def| def.length)
-            .unwrap_or(0)
+    fn array_length(&self, array_type: Type) -> u64 {
+        types::array_length_from_type(self.array_types, array_type)
     }
 
     /// Get the array type definition.
-    fn array_type_def(&self, array_type_id: ArrayTypeId) -> Option<&ArrayTypeDef> {
-        types::array_type_def(self.array_types, array_type_id)
+    fn array_type_def(&self, array_type: Type) -> Option<&ArrayTypeDef> {
+        types::array_type_def_from_type(self.array_types, array_type)
     }
 
     /// Calculate the total number of slots needed to store a type.
@@ -138,8 +130,8 @@ impl<'a> CfgLower<'a> {
     }
 
     /// Calculate the slot count for a single element of an array type.
-    fn array_element_slot_count(&self, array_type_id: ArrayTypeId) -> u32 {
-        types::array_element_slot_count(self.struct_defs, self.array_types, array_type_id)
+    fn array_element_slot_count(&self, array_type: Type) -> u32 {
+        types::array_element_slot_count_from_type(self.struct_defs, self.array_types, array_type)
     }
 
     /// Calculate the slot offset for a field within a struct.
@@ -169,17 +161,17 @@ impl<'a> CfgLower<'a> {
             }
             CfgInstData::IndexGet {
                 base: array_base,
-                array_type_id,
+                array_type,
                 index,
             } => {
                 // Array of structs case: the field's base is an IndexGet
                 // Try to trace the array base to find the original Load/Param
                 if let Some((index_base, mut levels)) = self.trace_index_chain(*array_base) {
-                    let elem_slot_count = self.array_element_slot_count(*array_type_id);
+                    let elem_slot_count = self.array_element_slot_count(*array_type);
                     levels.push(IndexLevel {
                         index: *index,
                         elem_slot_count,
-                        array_type_id: *array_type_id,
+                        array_type: *array_type,
                     });
                     Some((
                         FieldChainBase::IndexGet {
@@ -228,16 +220,16 @@ impl<'a> CfgLower<'a> {
             }
             CfgInstData::IndexGet {
                 base,
-                array_type_id,
+                array_type,
                 index,
             } => {
                 // Recursively trace the base
                 if let Some((base_kind, mut levels)) = self.trace_index_chain(*base) {
-                    let elem_slot_count = self.array_element_slot_count(*array_type_id);
+                    let elem_slot_count = self.array_element_slot_count(*array_type);
                     levels.push(IndexLevel {
                         index: *index,
                         elem_slot_count,
-                        array_type_id: *array_type_id,
+                        array_type: *array_type,
                     });
                     Some((base_kind, levels))
                 } else {
@@ -1805,9 +1797,9 @@ impl<'a> CfgLower<'a> {
                                 }
                             }
                         }
-                        Type::Array(array_type_id) => {
+                        Type::Array(_) => {
                             let arg_data = &self.cfg.get_inst(arg_value).data;
-                            let array_len = self.array_length(array_type_id) as u32;
+                            let array_len = self.array_length(arg_type) as u32;
                             match arg_data {
                                 CfgInstData::Load { slot } => {
                                     for elem_idx in 0..array_len {
@@ -2279,7 +2271,7 @@ impl<'a> CfgLower<'a> {
                             // Emit bounds check for the innermost index
                             if let Some(innermost) = index_levels.last() {
                                 let innermost_index_vreg = self.get_vreg(innermost.index);
-                                let array_length = self.array_length(innermost.array_type_id);
+                                let array_length = self.array_length(innermost.array_type);
                                 self.emit_bounds_check(innermost_index_vreg, array_length);
                             }
 
@@ -2487,7 +2479,6 @@ impl<'a> CfgLower<'a> {
             }
 
             CfgInstData::ArrayInit {
-                array_type_id: _,
                 elements_start,
                 elements_len,
             } => {
@@ -2509,14 +2500,14 @@ impl<'a> CfgLower<'a> {
 
             CfgInstData::IndexGet {
                 base,
-                array_type_id,
+                array_type,
                 index,
             } => {
                 let vreg = self.mir.alloc_vreg();
                 self.value_map.insert(value, vreg);
 
                 // Calculate the slot stride for this array's elements
-                let elem_slot_count = self.array_element_slot_count(*array_type_id);
+                let elem_slot_count = self.array_element_slot_count(*array_type);
 
                 // First, check if base is an ArrayInit (constant index case)
                 let base_data = &self.cfg.get_inst(*base).data.clone();
@@ -2548,12 +2539,12 @@ impl<'a> CfgLower<'a> {
                     levels.push(IndexLevel {
                         index: *index,
                         elem_slot_count,
-                        array_type_id: *array_type_id,
+                        array_type: *array_type,
                     });
 
                     // Emit bounds check for the innermost index
                     let innermost_index_vreg = self.get_vreg(*index);
-                    let array_length = self.array_length(*array_type_id);
+                    let array_length = self.array_length(*array_type);
                     self.emit_bounds_check(innermost_index_vreg, array_length);
 
                     // Calculate total offset by summing index * stride for each level
@@ -2679,7 +2670,7 @@ impl<'a> CfgLower<'a> {
 
             CfgInstData::IndexSet {
                 slot,
-                array_type_id,
+                array_type,
                 index,
                 value: val,
             } => {
@@ -2687,7 +2678,7 @@ impl<'a> CfgLower<'a> {
                 let index_vreg = self.get_vreg(*index);
 
                 // Emit runtime bounds check
-                let array_length = self.array_length(*array_type_id);
+                let array_length = self.array_length(*array_type);
                 self.emit_bounds_check(index_vreg, array_length);
 
                 // Shift left by 3 (multiply by 8)
@@ -2724,7 +2715,7 @@ impl<'a> CfgLower<'a> {
 
             CfgInstData::ParamIndexSet {
                 param_slot,
-                array_type_id,
+                array_type,
                 index,
                 value: val,
             } => {
@@ -2732,7 +2723,7 @@ impl<'a> CfgLower<'a> {
                 let index_vreg = self.get_vreg(*index);
 
                 // Emit runtime bounds check
-                let array_length = self.array_length(*array_type_id);
+                let array_length = self.array_length(*array_type);
                 self.emit_bounds_check(index_vreg, array_length);
 
                 // Shift left by 3 (multiply by 8)

--- a/crates/rue-codegen/src/cfg_lower.rs
+++ b/crates/rue-codegen/src/cfg_lower.rs
@@ -6,8 +6,7 @@
 use std::fmt;
 
 use lasso::Key;
-use rue_air::ArrayTypeId;
-use rue_cfg::{BlockId, CfgValue};
+use rue_cfg::{BlockId, CfgValue, Type};
 
 /// A single lowering decision: maps one CFG instruction to its MIR expansion.
 #[derive(Debug, Clone)]
@@ -177,32 +176,38 @@ pub fn format_cfg_inst_data(data: &rue_cfg::CfgInstData) -> String {
             "param_field_set %{}+{}.#{}.{} = {}",
             param_slot, inner_offset, struct_id.0, field_index, value
         ),
-        CfgInstData::ArrayInit { array_type_id, .. } => {
-            // Note: Can't show elements without Cfg access; just show array_type_id
-            format!("array_init @{} [...]", array_type_id.0)
+        CfgInstData::ArrayInit { .. } => {
+            // Note: Can't show elements without Cfg access
+            "array_init [...]".to_string()
         }
         CfgInstData::IndexGet {
             base,
-            array_type_id,
+            array_type,
             index,
-        } => format!("index_get {}[@{}][{}]", base, array_type_id.0, index),
+        } => format!("index_get {}[{}][{}]", base, array_type.name(), index),
         CfgInstData::IndexSet {
             slot,
-            array_type_id,
+            array_type,
             index,
             value,
         } => format!(
-            "index_set ${}[@{}][{}] = {}",
-            slot, array_type_id.0, index, value
+            "index_set ${}[{}][{}] = {}",
+            slot,
+            array_type.name(),
+            index,
+            value
         ),
         CfgInstData::ParamIndexSet {
             param_slot,
-            array_type_id,
+            array_type,
             index,
             value,
         } => format!(
-            "param_index_set %{}[@{}][{}] = {}",
-            param_slot, array_type_id.0, index, value
+            "param_index_set %{}[{}][{}] = {}",
+            param_slot,
+            array_type.name(),
+            index,
+            value
         ),
         CfgInstData::EnumVariant {
             enum_id,
@@ -334,5 +339,6 @@ pub enum IndexChainBase {
 pub struct IndexLevel {
     pub index: CfgValue,
     pub elem_slot_count: u32,
-    pub array_type_id: ArrayTypeId,
+    /// The array type (Type::Array(...)) for bounds checking.
+    pub array_type: Type,
 }

--- a/crates/rue-codegen/src/types.rs
+++ b/crates/rue-codegen/src/types.rs
@@ -9,12 +9,55 @@ use std::collections::HashMap;
 
 use crate::vreg::VReg;
 
+/// Extract the ArrayTypeId from a Type::Array.
+/// Returns None if the type is not an array type.
+#[inline]
+pub fn extract_array_type_id(ty: Type) -> Option<ArrayTypeId> {
+    match ty {
+        Type::Array(id) => Some(id),
+        _ => None,
+    }
+}
+
 /// Get the array type definition for an array type ID.
 pub fn array_type_def<'a>(
     array_types: &'a [ArrayTypeDef],
     array_type_id: ArrayTypeId,
 ) -> Option<&'a ArrayTypeDef> {
     array_types.get(array_type_id.0 as usize)
+}
+
+/// Get the array type definition from a Type.
+/// Returns None if the type is not an array type or if the ID is out of bounds.
+#[inline]
+pub fn array_type_def_from_type<'a>(
+    array_types: &'a [ArrayTypeDef],
+    ty: Type,
+) -> Option<&'a ArrayTypeDef> {
+    extract_array_type_id(ty).and_then(|id| array_type_def(array_types, id))
+}
+
+/// Get the length of an array from its Type.
+/// Returns 0 if the type is not an array or the ID is invalid.
+#[inline]
+pub fn array_length_from_type(array_types: &[ArrayTypeDef], ty: Type) -> u64 {
+    array_type_def_from_type(array_types, ty)
+        .map(|def| def.length)
+        .unwrap_or(0)
+}
+
+/// Calculate the slot count for a single element of an array from its Type.
+#[inline]
+pub fn array_element_slot_count_from_type(
+    struct_defs: &[StructDef],
+    array_types: &[ArrayTypeDef],
+    ty: Type,
+) -> u32 {
+    if let Some(def) = array_type_def_from_type(array_types, ty) {
+        type_slot_count(struct_defs, array_types, def.element_type)
+    } else {
+        1
+    }
 }
 
 /// Calculate the total number of slots needed to store a type.

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -28,7 +28,7 @@
 use std::collections::HashMap;
 
 use lasso::ThreadedRodeo;
-use rue_air::{ArrayTypeDef, ArrayTypeId};
+use rue_air::ArrayTypeDef;
 use rue_builtins::{BinOp, get_builtin_type};
 use rue_cfg::{
     BasicBlock, BlockId, Cfg, CfgInstData, CfgValue, StructDef, StructId, Terminator, Type,
@@ -127,21 +127,13 @@ impl<'a> CfgLower<'a> {
     }
 
     /// Get the length of an array type.
-    fn array_length(&self, array_type_id: ArrayTypeId) -> u64 {
-        debug_assert!(
-            (array_type_id.0 as usize) < self.array_types.len(),
-            "invalid array type ID: {:?}",
-            array_type_id
-        );
-        self.array_types
-            .get(array_type_id.0 as usize)
-            .map(|def| def.length)
-            .unwrap_or(0)
+    fn array_length(&self, array_type: Type) -> u64 {
+        types::array_length_from_type(self.array_types, array_type)
     }
 
     /// Get the array type definition.
-    fn array_type_def(&self, array_type_id: ArrayTypeId) -> Option<&ArrayTypeDef> {
-        types::array_type_def(self.array_types, array_type_id)
+    fn array_type_def(&self, array_type: Type) -> Option<&ArrayTypeDef> {
+        types::array_type_def_from_type(self.array_types, array_type)
     }
 
     // ========================================================================
@@ -188,8 +180,8 @@ impl<'a> CfgLower<'a> {
     }
 
     /// Calculate the slot count for a single element of an array type.
-    fn array_element_slot_count(&self, array_type_id: ArrayTypeId) -> u32 {
-        types::array_element_slot_count(self.struct_defs, self.array_types, array_type_id)
+    fn array_element_slot_count(&self, array_type: Type) -> u32 {
+        types::array_element_slot_count_from_type(self.struct_defs, self.array_types, array_type)
     }
 
     /// Calculate the slot offset for a field within a struct.
@@ -219,17 +211,17 @@ impl<'a> CfgLower<'a> {
             }
             CfgInstData::IndexGet {
                 base: array_base,
-                array_type_id,
+                array_type,
                 index,
             } => {
                 // Array of structs case: the field's base is an IndexGet
                 // Try to trace the array base to find the original Load/Param
                 if let Some((index_base, mut levels)) = self.trace_index_chain(*array_base) {
-                    let elem_slot_count = self.array_element_slot_count(*array_type_id);
+                    let elem_slot_count = self.array_element_slot_count(*array_type);
                     levels.push(IndexLevel {
                         index: *index,
                         elem_slot_count,
-                        array_type_id: *array_type_id,
+                        array_type: *array_type,
                     });
                     Some((
                         FieldChainBase::IndexGet {
@@ -278,16 +270,16 @@ impl<'a> CfgLower<'a> {
             }
             CfgInstData::IndexGet {
                 base,
-                array_type_id,
+                array_type,
                 index,
             } => {
                 // Recursively trace the base
                 if let Some((base_kind, mut levels)) = self.trace_index_chain(*base) {
-                    let elem_slot_count = self.array_element_slot_count(*array_type_id);
+                    let elem_slot_count = self.array_element_slot_count(*array_type);
                     levels.push(IndexLevel {
                         index: *index,
                         elem_slot_count,
-                        array_type_id: *array_type_id,
+                        array_type: *array_type,
                     });
                     Some((base_kind, levels))
                 } else {
@@ -1934,9 +1926,9 @@ impl<'a> CfgLower<'a> {
                                 }
                             }
                         }
-                        Type::Array(array_type_id) => {
+                        Type::Array(_) => {
                             let arg_data = &self.cfg.get_inst(arg_value).data;
-                            let array_len = self.array_length(array_type_id) as u32;
+                            let array_len = self.array_length(arg_type) as u32;
                             match arg_data {
                                 CfgInstData::Load { slot } => {
                                     for elem_idx in 0..array_len {
@@ -2426,7 +2418,7 @@ impl<'a> CfgLower<'a> {
                             // Emit bounds check for the innermost index
                             if let Some(innermost) = index_levels.last() {
                                 let innermost_index_vreg = self.get_vreg(innermost.index);
-                                let array_length = self.array_length(innermost.array_type_id);
+                                let array_length = self.array_length(innermost.array_type);
                                 self.emit_bounds_check(innermost_index_vreg, array_length);
                             }
 
@@ -2638,7 +2630,6 @@ impl<'a> CfgLower<'a> {
             }
 
             CfgInstData::ArrayInit {
-                array_type_id: _,
                 elements_start,
                 elements_len,
             } => {
@@ -2662,14 +2653,14 @@ impl<'a> CfgLower<'a> {
 
             CfgInstData::IndexGet {
                 base,
-                array_type_id,
+                array_type,
                 index,
             } => {
                 let vreg = self.mir.alloc_vreg();
                 self.value_map.insert(value, vreg);
 
                 // Calculate the slot stride for this array's elements
-                let elem_slot_count = self.array_element_slot_count(*array_type_id);
+                let elem_slot_count = self.array_element_slot_count(*array_type);
 
                 // First, check if base is an ArrayInit (constant index case)
                 let base_data = &self.cfg.get_inst(*base).data.clone();
@@ -2701,12 +2692,12 @@ impl<'a> CfgLower<'a> {
                     levels.push(IndexLevel {
                         index: *index,
                         elem_slot_count,
-                        array_type_id: *array_type_id,
+                        array_type: *array_type,
                     });
 
                     // Emit bounds check for the innermost index
                     let innermost_index_vreg = self.get_vreg(*index);
-                    let array_length = self.array_length(*array_type_id);
+                    let array_length = self.array_length(*array_type);
                     self.emit_bounds_check(innermost_index_vreg, array_length);
 
                     // Calculate total offset by summing index * stride for each level
@@ -2882,7 +2873,7 @@ impl<'a> CfgLower<'a> {
 
             CfgInstData::IndexSet {
                 slot,
-                array_type_id,
+                array_type,
                 index,
                 value: val,
             } => {
@@ -2890,12 +2881,12 @@ impl<'a> CfgLower<'a> {
                 let index_vreg = self.get_vreg(*index);
 
                 // Emit runtime bounds check
-                let array_length = self.array_length(*array_type_id);
+                let array_length = self.array_length(*array_type);
                 self.emit_bounds_check(index_vreg, array_length);
 
                 // Optimization: use SIB addressing for single-element arrays
                 // This is always the case for IndexSet (it doesn't chain like IndexGet)
-                let elem_slot_count = self.array_element_slot_count(*array_type_id);
+                let elem_slot_count = self.array_element_slot_count(*array_type);
 
                 let base_offset = self.local_offset(*slot);
 
@@ -2971,7 +2962,7 @@ impl<'a> CfgLower<'a> {
 
             CfgInstData::ParamIndexSet {
                 param_slot,
-                array_type_id,
+                array_type,
                 index,
                 value: val,
             } => {
@@ -2979,7 +2970,7 @@ impl<'a> CfgLower<'a> {
                 let index_vreg = self.get_vreg(*index);
 
                 // Emit runtime bounds check
-                let array_length = self.array_length(*array_type_id);
+                let array_length = self.array_length(*array_type);
                 self.emit_bounds_check(index_vreg, array_length);
 
                 // Scale index by 8 (element size)

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -166,6 +166,11 @@ impl ErrorCode {
     pub const PREVIEW_FEATURE_REQUIRED: Self = Self(1100);
 
     // ========================================================================
+    // Comptime errors (E1200-E1299)
+    // ========================================================================
+    pub const COMPTIME_EVALUATION_FAILED: Self = Self(1200);
+
+    // ========================================================================
     // Internal compiler errors (E9000-E9999)
     // ========================================================================
     pub const INTERNAL_ERROR: Self = Self(9000);
@@ -241,6 +246,9 @@ pub enum PreviewFeature {
     /// Affine types and mutable value semantics.
     /// See ADR-0008 for the full design.
     AffineMvs,
+    /// Compile-time execution (comptime).
+    /// See ADR-0025 for the full design.
+    Comptime,
 }
 
 /// Error returned when parsing a preview feature name fails.
@@ -262,6 +270,7 @@ impl PreviewFeature {
         match *self {
             PreviewFeature::TestInfra => "test_infra",
             PreviewFeature::AffineMvs => "affine_mvs",
+            PreviewFeature::Comptime => "comptime",
         }
     }
 
@@ -271,12 +280,17 @@ impl PreviewFeature {
         match *self {
             PreviewFeature::TestInfra => "ADR-0005",
             PreviewFeature::AffineMvs => "ADR-0008",
+            PreviewFeature::Comptime => "ADR-0025",
         }
     }
 
     /// Get all available preview features.
     pub fn all() -> &'static [PreviewFeature] {
-        &[PreviewFeature::TestInfra, PreviewFeature::AffineMvs]
+        &[
+            PreviewFeature::TestInfra,
+            PreviewFeature::AffineMvs,
+            PreviewFeature::Comptime,
+        ]
     }
 
     /// Get a comma-separated list of all feature names (for help text).
@@ -300,6 +314,7 @@ impl std::str::FromStr for PreviewFeature {
         match s {
             "test_infra" => Ok(PreviewFeature::TestInfra),
             "affine_mvs" => Ok(PreviewFeature::AffineMvs),
+            "comptime" => Ok(PreviewFeature::Comptime),
             _ => Err(ParsePreviewFeatureError(s.to_string())),
         }
     }
@@ -961,6 +976,10 @@ pub enum ErrorKind {
         what: String,
     },
 
+    // Comptime errors
+    #[error("comptime evaluation failed: {reason}")]
+    ComptimeEvaluationFailed { reason: String },
+
     // Internal compiler errors (bugs in the compiler itself)
     #[error("internal compiler error: {0}")]
     InternalError(String),
@@ -1066,6 +1085,9 @@ impl ErrorKind {
 
             // Preview feature errors (E1100-E1199)
             ErrorKind::PreviewFeatureRequired { .. } => ErrorCode::PREVIEW_FEATURE_REQUIRED,
+
+            // Comptime errors (E1200-E1299)
+            ErrorKind::ComptimeEvaluationFailed { .. } => ErrorCode::COMPTIME_EVALUATION_FAILED,
 
             // Internal compiler errors (E9000-E9999)
             ErrorKind::InternalError(_) => ErrorCode::INTERNAL_ERROR,
@@ -1764,7 +1786,7 @@ mod tests {
     #[test]
     fn test_preview_feature_all_names() {
         let names = PreviewFeature::all_names();
-        assert_eq!(names, "test_infra, affine_mvs");
+        assert_eq!(names, "test_infra, affine_mvs, comptime");
     }
 
     // ========================================================================

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -249,6 +249,9 @@ pub enum PreviewFeature {
     /// Compile-time execution (comptime).
     /// See ADR-0025 for the full design.
     Comptime,
+    /// Module system with @import and pub visibility.
+    /// See ADR-0026 for the full design.
+    Modules,
 }
 
 /// Error returned when parsing a preview feature name fails.
@@ -271,6 +274,7 @@ impl PreviewFeature {
             PreviewFeature::TestInfra => "test_infra",
             PreviewFeature::AffineMvs => "affine_mvs",
             PreviewFeature::Comptime => "comptime",
+            PreviewFeature::Modules => "modules",
         }
     }
 
@@ -281,6 +285,7 @@ impl PreviewFeature {
             PreviewFeature::TestInfra => "ADR-0005",
             PreviewFeature::AffineMvs => "ADR-0008",
             PreviewFeature::Comptime => "ADR-0025",
+            PreviewFeature::Modules => "ADR-0026",
         }
     }
 
@@ -290,6 +295,7 @@ impl PreviewFeature {
             PreviewFeature::TestInfra,
             PreviewFeature::AffineMvs,
             PreviewFeature::Comptime,
+            PreviewFeature::Modules,
         ]
     }
 
@@ -315,6 +321,7 @@ impl std::str::FromStr for PreviewFeature {
             "test_infra" => Ok(PreviewFeature::TestInfra),
             "affine_mvs" => Ok(PreviewFeature::AffineMvs),
             "comptime" => Ok(PreviewFeature::Comptime),
+            "modules" => Ok(PreviewFeature::Modules),
             _ => Err(ParsePreviewFeatureError(s.to_string())),
         }
     }
@@ -1786,7 +1793,7 @@ mod tests {
     #[test]
     fn test_preview_feature_all_names() {
         let names = PreviewFeature::all_names();
-        assert_eq!(names, "test_infra, affine_mvs, comptime");
+        assert_eq!(names, "test_infra, affine_mvs, comptime, modules");
     }
 
     // ========================================================================

--- a/crates/rue-lexer/src/lib.rs
+++ b/crates/rue-lexer/src/lib.rs
@@ -40,6 +40,7 @@ pub enum TokenKind {
     Drop,
     Linear,    // linear struct modifier
     SelfValue, // self (value, not type)
+    Comptime,  // comptime (compile-time evaluation)
 
     // Type keywords
     I8,
@@ -130,6 +131,7 @@ impl TokenKind {
             TokenKind::Drop => "'drop'",
             TokenKind::Linear => "'linear'",
             TokenKind::SelfValue => "'self'",
+            TokenKind::Comptime => "'comptime'",
             TokenKind::I8 => "type 'i8'",
             TokenKind::I16 => "type 'i16'",
             TokenKind::I32 => "type 'i32'",
@@ -224,6 +226,7 @@ impl std::fmt::Display for TokenKind {
             TokenKind::Drop => write!(f, "DROP"),
             TokenKind::Linear => write!(f, "LINEAR"),
             TokenKind::SelfValue => write!(f, "SELF"),
+            TokenKind::Comptime => write!(f, "COMPTIME"),
             TokenKind::I8 => write!(f, "TYPE(i8)"),
             TokenKind::I16 => write!(f, "TYPE(i16)"),
             TokenKind::I32 => write!(f, "TYPE(i32)"),

--- a/crates/rue-lexer/src/lib.rs
+++ b/crates/rue-lexer/src/lib.rs
@@ -41,6 +41,7 @@ pub enum TokenKind {
     Linear,    // linear struct modifier
     SelfValue, // self (value, not type)
     Comptime,  // comptime (compile-time evaluation)
+    Pub,       // pub visibility modifier (module system)
 
     // Type keywords
     I8,
@@ -132,6 +133,7 @@ impl TokenKind {
             TokenKind::Linear => "'linear'",
             TokenKind::SelfValue => "'self'",
             TokenKind::Comptime => "'comptime'",
+            TokenKind::Pub => "'pub'",
             TokenKind::I8 => "type 'i8'",
             TokenKind::I16 => "type 'i16'",
             TokenKind::I32 => "type 'i32'",
@@ -227,6 +229,7 @@ impl std::fmt::Display for TokenKind {
             TokenKind::Linear => write!(f, "LINEAR"),
             TokenKind::SelfValue => write!(f, "SELF"),
             TokenKind::Comptime => write!(f, "COMPTIME"),
+            TokenKind::Pub => write!(f, "PUB"),
             TokenKind::I8 => write!(f, "TYPE(i8)"),
             TokenKind::I16 => write!(f, "TYPE(i16)"),
             TokenKind::I32 => write!(f, "TYPE(i32)"),

--- a/crates/rue-lexer/src/logos_lexer.rs
+++ b/crates/rue-lexer/src/logos_lexer.rs
@@ -151,6 +151,8 @@ pub enum LogosTokenKind {
     Linear,
     #[token("self")]
     SelfValue,
+    #[token("comptime")]
+    Comptime,
 
     // Type keywords
     #[token("i8")]
@@ -292,6 +294,7 @@ impl From<LogosTokenKind> for TokenKind {
             LogosTokenKind::Drop => TokenKind::Drop,
             LogosTokenKind::Linear => TokenKind::Linear,
             LogosTokenKind::SelfValue => TokenKind::SelfValue,
+            LogosTokenKind::Comptime => TokenKind::Comptime,
             LogosTokenKind::I8 => TokenKind::I8,
             LogosTokenKind::I16 => TokenKind::I16,
             LogosTokenKind::I32 => TokenKind::I32,

--- a/crates/rue-lexer/src/logos_lexer.rs
+++ b/crates/rue-lexer/src/logos_lexer.rs
@@ -153,6 +153,8 @@ pub enum LogosTokenKind {
     SelfValue,
     #[token("comptime")]
     Comptime,
+    #[token("pub")]
+    Pub,
 
     // Type keywords
     #[token("i8")]
@@ -295,6 +297,7 @@ impl From<LogosTokenKind> for TokenKind {
             LogosTokenKind::Linear => TokenKind::Linear,
             LogosTokenKind::SelfValue => TokenKind::SelfValue,
             LogosTokenKind::Comptime => TokenKind::Comptime,
+            LogosTokenKind::Pub => TokenKind::Pub,
             LogosTokenKind::I8 => TokenKind::I8,
             LogosTokenKind::I16 => TokenKind::I16,
             LogosTokenKind::I32 => TokenKind::I32,

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -326,6 +326,8 @@ pub enum Expr {
     AssocFnCall(AssocFnCallExpr),
     /// Self expression (e.g., `self` in method bodies)
     SelfExpr(SelfExpr),
+    /// Comptime block expression (e.g., `comptime { 1 + 2 }`)
+    Comptime(ComptimeBlockExpr),
 }
 
 /// An integer literal.
@@ -755,6 +757,15 @@ pub struct SelfExpr {
     pub span: Span,
 }
 
+/// A comptime block expression (e.g., `comptime { 1 + 2 }`).
+/// The expression inside must be evaluable at compile time.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ComptimeBlockExpr {
+    /// The expression to evaluate at compile time
+    pub expr: Box<Expr>,
+    pub span: Span,
+}
+
 impl Expr {
     /// Get the span of this expression.
     pub fn span(&self) -> Span {
@@ -785,6 +796,7 @@ impl Expr {
             Expr::Path(path_expr) => path_expr.span,
             Expr::AssocFnCall(assoc_fn_call) => assoc_fn_call.span,
             Expr::SelfExpr(self_expr) => self_expr.span,
+            Expr::Comptime(comptime_expr) => comptime_expr.span,
         }
     }
 }
@@ -1100,6 +1112,10 @@ fn fmt_expr(f: &mut fmt::Formatter<'_>, expr: &Expr, level: usize) -> fmt::Resul
         }
         Expr::SelfExpr(_) => {
             writeln!(f, "SelfExpr")
+        }
+        Expr::Comptime(comptime) => {
+            writeln!(f, "Comptime")?;
+            fmt_expr(f, &comptime.expr, level + 1)
         }
     }
 }

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -76,6 +76,8 @@ pub enum Item {
 pub struct StructDecl {
     /// Directives applied to this struct (e.g., @copy)
     pub directives: Directives,
+    /// Visibility of this struct
+    pub visibility: Visibility,
     /// Whether this struct is a linear type (must be consumed, cannot be dropped)
     pub is_linear: bool,
     /// Struct name
@@ -100,6 +102,8 @@ pub struct FieldDecl {
 /// An enum declaration.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EnumDecl {
+    /// Visibility of this enum
+    pub visibility: Visibility,
     /// Enum name
     pub name: Ident,
     /// Enum variants
@@ -169,11 +173,23 @@ pub struct SelfParam {
     pub span: Span,
 }
 
+/// Visibility of an item (function, struct, enum, etc.)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Visibility {
+    /// Private to the current file (default)
+    #[default]
+    Private,
+    /// Public - visible to importers
+    Public,
+}
+
 /// A function definition.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Function {
     /// Directives applied to this function
     pub directives: Directives,
+    /// Visibility of this function
+    pub visibility: Visibility,
     /// Function name
     pub name: Ident,
     /// Function parameters

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -5,13 +5,13 @@
 
 use crate::ast::{
     ArgMode, ArrayLitExpr, AssignStatement, AssignTarget, AssocFnCallExpr, Ast, BinaryExpr,
-    BinaryOp, BlockExpr, BoolLit, BreakExpr, CallArg, CallExpr, ContinueExpr, Directive,
-    DirectiveArg, Directives, DropFn, EnumDecl, EnumVariant, Expr, FieldDecl, FieldExpr, FieldInit,
-    Function, Ident, IfExpr, ImplBlock, IndexExpr, IntLit, IntrinsicArg, IntrinsicCallExpr, Item,
-    LetPattern, LetStatement, LoopExpr, MatchArm, MatchExpr, Method, MethodCallExpr, NegIntLit,
-    Param, ParamMode, ParenExpr, PathExpr, PathPattern, Pattern, ReturnExpr, SelfExpr, SelfParam,
-    Statement, StringLit, StructDecl, StructLitExpr, TypeExpr, UnaryExpr, UnaryOp, UnitLit,
-    WhileExpr,
+    BinaryOp, BlockExpr, BoolLit, BreakExpr, CallArg, CallExpr, ComptimeBlockExpr, ContinueExpr,
+    Directive, DirectiveArg, Directives, DropFn, EnumDecl, EnumVariant, Expr, FieldDecl, FieldExpr,
+    FieldInit, Function, Ident, IfExpr, ImplBlock, IndexExpr, IntLit, IntrinsicArg,
+    IntrinsicCallExpr, Item, LetPattern, LetStatement, LoopExpr, MatchArm, MatchExpr, Method,
+    MethodCallExpr, NegIntLit, Param, ParamMode, ParenExpr, PathExpr, PathPattern, Pattern,
+    ReturnExpr, SelfExpr, SelfParam, Statement, StringLit, StructDecl, StructLitExpr, TypeExpr,
+    UnaryExpr, UnaryOp, UnitLit, WhileExpr,
 };
 use chumsky::input::{Input as ChumskyInput, MapExtra, Stream, ValueInput};
 use chumsky::pratt::{infix, left, prefix};
@@ -1012,6 +1012,16 @@ where
     // Block expression
     let block_expr = block_parser(expr.clone());
 
+    // Comptime block expression: comptime { expr }
+    let comptime_expr = just(TokenKind::Comptime)
+        .ignore_then(block_parser(expr.clone()))
+        .map_with(|inner_expr, e| {
+            Expr::Comptime(ComptimeBlockExpr {
+                expr: Box::new(inner_expr),
+                span: to_rue_span(e.span()),
+            })
+        });
+
     // Intrinsic argument: can be either a type or an expression
     // We parse as type only for unambiguous type syntax (primitives, (), !, [T;N])
     // Bare identifiers are parsed as expressions since they could be variables
@@ -1082,6 +1092,7 @@ where
     // Note: literal_parser() includes unit_lit which must come before paren_expr
     // so () is parsed as unit, not empty parens
     // Note: self_expr must come before call_and_access_parser since self is a keyword
+    // Note: comptime_expr must come before block_expr since comptime starts with a keyword
     let primary = choice((
         literal_parser(),
         control_flow_parser(expr.clone()),
@@ -1090,6 +1101,7 @@ where
         array_lit,
         call_and_access_parser(expr.clone()),
         paren_expr,
+        comptime_expr,
         block_expr,
     ));
 

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -11,7 +11,7 @@ use crate::ast::{
     IntrinsicCallExpr, Item, LetPattern, LetStatement, LoopExpr, MatchArm, MatchExpr, Method,
     MethodCallExpr, NegIntLit, Param, ParamMode, ParenExpr, PathExpr, PathPattern, Pattern,
     ReturnExpr, SelfExpr, SelfParam, Statement, StringLit, StructDecl, StructLitExpr, TypeExpr,
-    UnaryExpr, UnaryOp, UnitLit, WhileExpr,
+    UnaryExpr, UnaryOp, UnitLit, Visibility, WhileExpr,
 };
 use chumsky::input::{Input as ChumskyInput, MapExtra, Stream, ValueInput};
 use chumsky::pratt::{infix, left, prefix};
@@ -1513,14 +1513,25 @@ where
 {
     let expr = expr_parser();
 
+    // Parse optional visibility (pub keyword)
+    let visibility = just(TokenKind::Pub).or_not().map(|opt| {
+        if opt.is_some() {
+            Visibility::Public
+        } else {
+            Visibility::Private
+        }
+    });
+
     directives_parser()
+        .then(visibility)
         .then(just(TokenKind::Fn).ignore_then(ident_parser()))
         .then(params_parser().delimited_by(just(TokenKind::LParen), just(TokenKind::RParen)))
         .then(just(TokenKind::Arrow).ignore_then(type_parser()).or_not())
         .then(block_parser(expr))
         .map_with(
-            |((((directives, name), params), return_type), body), e| Function {
+            |(((((directives, visibility), name), params), return_type), body), e| Function {
                 directives,
+                visibility,
                 name,
                 params,
                 return_type,
@@ -1530,22 +1541,35 @@ where
         )
 }
 
-/// Parser for struct definitions: [@directive]* [linear] struct Name { field: Type, ... }
+/// Parser for struct definitions: [@directive]* [pub] [linear] struct Name { field: Type, ... }
 fn struct_parser<'src, I>() -> impl Parser<'src, I, StructDecl, ParserExtras<'src>> + Clone
 where
     I: ValueInput<'src, Token = TokenKind, Span = SimpleSpan>,
 {
+    // Parse optional visibility (pub keyword)
+    let visibility = just(TokenKind::Pub).or_not().map(|opt| {
+        if opt.is_some() {
+            Visibility::Public
+        } else {
+            Visibility::Private
+        }
+    });
+
     directives_parser()
+        .then(visibility)
         .then(just(TokenKind::Linear).or_not())
         .then(just(TokenKind::Struct).ignore_then(ident_parser()))
         .then(field_decls_parser().delimited_by(just(TokenKind::LBrace), just(TokenKind::RBrace)))
-        .map_with(|(((directives, is_linear), name), fields), e| StructDecl {
-            directives,
-            is_linear: is_linear.is_some(),
-            name,
-            fields,
-            span: to_rue_span(e.span()),
-        })
+        .map_with(
+            |((((directives, visibility), is_linear), name), fields), e| StructDecl {
+                directives,
+                visibility,
+                is_linear: is_linear.is_some(),
+                name,
+                fields,
+                span: to_rue_span(e.span()),
+            },
+        )
 }
 
 /// Parser for enum variant: just an identifier
@@ -1571,15 +1595,25 @@ where
         .collect()
 }
 
-/// Parser for enum definitions: enum Name { Variant1, Variant2, ... }
+/// Parser for enum definitions: [pub] enum Name { Variant1, Variant2, ... }
 fn enum_parser<'src, I>() -> impl Parser<'src, I, EnumDecl, ParserExtras<'src>> + Clone
 where
     I: ValueInput<'src, Token = TokenKind, Span = SimpleSpan>,
 {
-    just(TokenKind::Enum)
-        .ignore_then(ident_parser())
+    // Parse optional visibility (pub keyword)
+    let visibility = just(TokenKind::Pub).or_not().map(|opt| {
+        if opt.is_some() {
+            Visibility::Public
+        } else {
+            Visibility::Private
+        }
+    });
+
+    visibility
+        .then(just(TokenKind::Enum).ignore_then(ident_parser()))
         .then(enum_variants_parser().delimited_by(just(TokenKind::LBrace), just(TokenKind::RBrace)))
-        .map_with(|(name, variants), e| EnumDecl {
+        .map_with(|((visibility, name), variants), e| EnumDecl {
+            visibility,
             name,
             variants,
             span: to_rue_span(e.span()),

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -633,6 +633,15 @@ impl<'a> AstGen<'a> {
                     span: self_expr.span,
                 })
             }
+            Expr::Comptime(comptime_block) => {
+                // Generate the inner expression, wrapped in a Comptime instruction
+                // The semantic analyzer will evaluate this at compile time
+                let inner_expr = self.gen_expr(&comptime_block.expr);
+                self.rir.add_inst(Inst {
+                    data: InstData::Comptime { expr: inner_expr },
+                    span: comptime_block.span,
+                })
+            }
         }
     }
 

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -12,7 +12,7 @@ use rue_parser::ast::DropFn;
 use rue_parser::{
     ArgMode, AssignTarget, Ast, BinaryOp, CallArg, Directive, DirectiveArg, EnumDecl, Expr,
     Function, ImplBlock, IntrinsicArg, Item, LetPattern, Method, ParamMode, Pattern, Statement,
-    StructDecl, TypeExpr, UnaryOp,
+    StructDecl, TypeExpr, UnaryOp, ast::Visibility,
 };
 
 use crate::inst::{
@@ -109,6 +109,7 @@ impl<'a> AstGen<'a> {
             data: InstData::StructDecl {
                 directives_start,
                 directives_len,
+                is_pub: struct_decl.visibility == Visibility::Public,
                 is_linear: struct_decl.is_linear,
                 name,
                 fields_start,
@@ -129,6 +130,7 @@ impl<'a> AstGen<'a> {
 
         self.rir.add_inst(Inst {
             data: InstData::EnumDecl {
+                is_pub: enum_decl.visibility == Visibility::Public,
                 name,
                 variants_start,
                 variants_len,
@@ -205,10 +207,12 @@ impl<'a> AstGen<'a> {
 
         // Emit methods as FnDecl instructions with has_self flag.
         // Sema uses has_self to add the implicit self parameter for methods.
+        // Methods don't have their own visibility - they're accessible if the type is accessible.
         let decl = self.rir.add_inst(Inst {
             data: InstData::FnDecl {
                 directives_start,
                 directives_len,
+                is_pub: false,
                 name,
                 params_start,
                 params_len,
@@ -307,6 +311,7 @@ impl<'a> AstGen<'a> {
             data: InstData::FnDecl {
                 directives_start,
                 directives_len,
+                is_pub: func.visibility == Visibility::Public,
                 name,
                 params_start,
                 params_len,

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -1071,6 +1071,9 @@ impl Rir {
                 type_name: *type_name,
                 body: renumber(*body),
             },
+            InstData::Comptime { expr } => InstData::Comptime {
+                expr: renumber(*expr),
+            },
         };
 
         Inst {
@@ -1245,7 +1248,8 @@ impl Rir {
                 | InstData::IndexGet { .. }
                 | InstData::IndexSet { .. }
                 | InstData::TypeIntrinsic { .. }
-                | InstData::DropFnDecl { .. } => {}
+                | InstData::DropFnDecl { .. }
+                | InstData::Comptime { .. } => {}
             }
         }
     }
@@ -1599,6 +1603,13 @@ pub enum InstData {
         type_name: Spur,
         /// Destructor body instruction ref
         body: InstRef,
+    },
+
+    /// Comptime block expression: comptime { expr }
+    /// The inner expression must be evaluable at compile time.
+    Comptime {
+        /// The expression to evaluate at compile time
+        expr: InstRef,
     },
 }
 
@@ -2004,6 +2015,11 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     .unwrap();
                     writeln!(out, "    {}", body).unwrap();
                     writeln!(out, "}}").unwrap();
+                }
+
+                // Comptime block
+                InstData::Comptime { expr } => {
+                    writeln!(out, "comptime {{ {} }}", expr).unwrap();
                 }
             }
         }

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -932,6 +932,7 @@ impl Rir {
             InstData::FnDecl {
                 directives_start,
                 directives_len,
+                is_pub,
                 name,
                 params_start,
                 params_len,
@@ -941,6 +942,7 @@ impl Rir {
             } => InstData::FnDecl {
                 directives_start: *directives_start + extra_offset,
                 directives_len: *directives_len,
+                is_pub: *is_pub,
                 name: *name,
                 params_start: *params_start + extra_offset,
                 params_len: *params_len,
@@ -975,6 +977,7 @@ impl Rir {
             InstData::StructDecl {
                 directives_start,
                 directives_len,
+                is_pub,
                 is_linear,
                 name,
                 fields_start,
@@ -982,6 +985,7 @@ impl Rir {
             } => InstData::StructDecl {
                 directives_start: *directives_start + extra_offset,
                 directives_len: *directives_len,
+                is_pub: *is_pub,
                 is_linear: *is_linear,
                 name: *name,
                 fields_start: *fields_start + extra_offset,
@@ -1008,10 +1012,12 @@ impl Rir {
 
             // Enum operations
             InstData::EnumDecl {
+                is_pub,
                 name,
                 variants_start,
                 variants_len,
             } => InstData::EnumDecl {
+                is_pub: *is_pub,
                 name: *name,
                 variants_start: *variants_start + extra_offset,
                 variants_len: *variants_len,
@@ -1368,6 +1374,8 @@ pub enum InstData {
         directives_start: u32,
         /// Number of directives
         directives_len: u32,
+        /// Whether this function is public (requires --preview modules)
+        is_pub: bool,
         name: Spur,
         /// Index into extra data where params start
         params_start: u32,
@@ -1472,6 +1480,8 @@ pub enum InstData {
         directives_start: u32,
         /// Number of directives
         directives_len: u32,
+        /// Whether this struct is public (requires --preview modules)
+        is_pub: bool,
         /// Whether this struct is a linear type (must be consumed)
         is_linear: bool,
         /// Struct name
@@ -1515,6 +1525,8 @@ pub enum InstData {
     /// Enum type declaration
     /// Variants are stored in the extra array using add_symbols/get_symbols.
     EnumDecl {
+        /// Whether this enum is public (requires --preview modules)
+        is_pub: bool,
         /// Enum name
         name: Spur,
         /// Index into extra data where variants start
@@ -1740,6 +1752,7 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                 InstData::FnDecl {
                     directives_start: _,
                     directives_len: _,
+                    is_pub,
                     name,
                     params_start,
                     params_len,
@@ -1747,6 +1760,7 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     body,
                     has_self,
                 } => {
+                    let pub_str = if *is_pub { "pub " } else { "" };
                     let name_str = self.interner.resolve(&*name);
                     let ret_str = self.interner.resolve(&*return_type);
                     let self_str = if *has_self { "self, " } else { "" };
@@ -1769,7 +1783,8 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                         .collect();
                     writeln!(
                         out,
-                        "fn {}({}{}) -> {} {{",
+                        "{}fn {}({}{}) -> {} {{",
+                        pub_str,
                         name_str,
                         self_str,
                         params_str.join(", "),
@@ -1846,11 +1861,13 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                 InstData::StructDecl {
                     directives_start,
                     directives_len,
+                    is_pub,
                     is_linear,
                     name,
                     fields_start,
                     fields_len,
                 } => {
+                    let pub_str = if *is_pub { "pub " } else { "" };
                     let name_str = self.interner.resolve(&*name);
                     let fields = self.rir.get_field_decls(*fields_start, *fields_len);
                     let fields_str: Vec<String> = fields
@@ -1876,8 +1893,9 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     };
                     writeln!(
                         out,
-                        "{}{}struct {} {{ {} }}",
+                        "{}{}{}struct {} {{ {} }}",
                         directives_str,
+                        pub_str,
                         linear_str,
                         name_str,
                         fields_str.join(", ")
@@ -1921,17 +1939,26 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
 
                 // Enums
                 InstData::EnumDecl {
+                    is_pub,
                     name,
                     variants_start,
                     variants_len,
                 } => {
+                    let pub_str = if *is_pub { "pub " } else { "" };
                     let name_str = self.interner.resolve(&*name);
                     let variants = self.rir.get_symbols(*variants_start, *variants_len);
                     let variants_str: Vec<String> = variants
                         .iter()
                         .map(|v| self.interner.resolve(&*v).to_string())
                         .collect();
-                    writeln!(out, "enum {} {{ {} }}", name_str, variants_str.join(", ")).unwrap();
+                    writeln!(
+                        out,
+                        "{}enum {} {{ {} }}",
+                        pub_str,
+                        name_str,
+                        variants_str.join(", ")
+                    )
+                    .unwrap();
                 }
                 InstData::EnumVariant { type_name, variant } => {
                     writeln!(
@@ -2513,6 +2540,7 @@ mod tests {
             data: InstData::FnDecl {
                 directives_start,
                 directives_len,
+                is_pub: false,
                 name,
                 params_start,
                 params_len,
@@ -2546,6 +2574,7 @@ mod tests {
             data: InstData::FnDecl {
                 directives_start,
                 directives_len,
+                is_pub: false,
                 name,
                 params_start,
                 params_len,
@@ -2601,6 +2630,7 @@ mod tests {
             data: InstData::FnDecl {
                 directives_start,
                 directives_len,
+                is_pub: false,
                 name,
                 params_start,
                 params_len,
@@ -2908,6 +2938,7 @@ mod tests {
             data: InstData::StructDecl {
                 directives_start,
                 directives_len,
+                is_pub: false,
                 is_linear: false,
                 name,
                 fields_start,
@@ -2940,6 +2971,7 @@ mod tests {
             data: InstData::StructDecl {
                 directives_start,
                 directives_len,
+                is_pub: false,
                 is_linear: false,
                 name,
                 fields_start,
@@ -3041,6 +3073,7 @@ mod tests {
 
         rir.add_inst(Inst {
             data: InstData::EnumDecl {
+                is_pub: false,
                 name,
                 variants_start,
                 variants_len,
@@ -3168,6 +3201,7 @@ mod tests {
             data: InstData::FnDecl {
                 directives_start,
                 directives_len,
+                is_pub: false,
                 name: method_name,
                 params_start,
                 params_len,
@@ -3747,6 +3781,7 @@ mod tests {
             data: InstData::FnDecl {
                 directives_start: dirs_start,
                 directives_len: dirs_len,
+                is_pub: false,
                 name: main_name,
                 params_start,
                 params_len,
@@ -3771,6 +3806,7 @@ mod tests {
             data: InstData::FnDecl {
                 directives_start: dirs_start2,
                 directives_len: dirs_len2,
+                is_pub: false,
                 name: helper_name,
                 params_start: params_start2,
                 params_len: params_len2,

--- a/crates/rue-spec/cases/expressions/comptime.toml
+++ b/crates/rue-spec/cases/expressions/comptime.toml
@@ -1,0 +1,265 @@
+# Compile-Time Execution (comptime) Tests
+#
+# Tests for the comptime block expression feature (ADR-0025, Phase 1).
+# This is a preview feature that must be enabled with --preview comptime.
+
+[section]
+id = "expressions.comptime"
+spec_chapter = "4.13"
+name = "Compile-Time Execution"
+description = "Comptime blocks evaluate expressions at compile time."
+
+# =============================================================================
+# Preview Feature Gating
+# =============================================================================
+
+[[case]]
+name = "comptime_requires_preview_flag"
+spec = ["4.13:1"]
+source = """
+fn main() -> i32 {
+    comptime { 42 }
+}
+"""
+compile_fail = true
+error_contains = "requires preview feature"
+
+[[case]]
+name = "comptime_error_includes_help"
+spec = ["4.13:1"]
+source = """
+fn main() -> i32 {
+    comptime { 1 + 2 }
+}
+"""
+compile_fail = true
+error_contains = "--preview comptime"
+
+# =============================================================================
+# Basic Comptime Expressions
+# =============================================================================
+
+[[case]]
+name = "comptime_integer_literal"
+spec = ["4.13:2"]
+preview = "comptime"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    comptime { 42 }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_addition"
+spec = ["4.13:2"]
+preview = "comptime"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    comptime { 1 + 2 + 3 }
+}
+"""
+exit_code = 6
+
+[[case]]
+name = "comptime_complex_arithmetic"
+spec = ["4.13:2"]
+preview = "comptime"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    comptime { 1 + 2 * 3 }
+}
+"""
+exit_code = 7
+
+[[case]]
+name = "comptime_subtraction"
+spec = ["4.13:2"]
+preview = "comptime"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    comptime { 10 - 3 }
+}
+"""
+exit_code = 7
+
+[[case]]
+name = "comptime_multiplication"
+spec = ["4.13:2"]
+preview = "comptime"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    comptime { 6 * 7 }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_division"
+spec = ["4.13:2"]
+preview = "comptime"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    comptime { 84 / 2 }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_modulo"
+spec = ["4.13:2"]
+preview = "comptime"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    comptime { 47 % 5 }
+}
+"""
+exit_code = 2
+
+[[case]]
+name = "comptime_boolean_true"
+spec = ["4.13:2"]
+preview = "comptime"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    if comptime { true } { 42 } else { 0 }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_boolean_false"
+spec = ["4.13:2"]
+preview = "comptime"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    if comptime { false } { 0 } else { 42 }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_comparison"
+spec = ["4.13:2"]
+preview = "comptime"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    if comptime { 10 > 5 } { 42 } else { 0 }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_equality"
+spec = ["4.13:2"]
+preview = "comptime"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    if comptime { 5 == 5 } { 42 } else { 0 }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_logical_and"
+spec = ["4.13:2"]
+preview = "comptime"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    if comptime { true && true } { 42 } else { 0 }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_logical_or"
+spec = ["4.13:2"]
+preview = "comptime"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    if comptime { false || true } { 42 } else { 0 }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_bitwise_and"
+spec = ["4.13:2"]
+preview = "comptime"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    comptime { 255 & 15 }
+}
+"""
+exit_code = 15
+
+[[case]]
+name = "comptime_bitwise_or"
+spec = ["4.13:2"]
+preview = "comptime"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    comptime { 240 | 15 }
+}
+"""
+exit_code = 255
+
+[[case]]
+name = "comptime_in_let_binding"
+spec = ["4.13:3"]
+preview = "comptime"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    let x: i32 = comptime { 21 * 2 };
+    x
+}
+"""
+exit_code = 42
+
+# =============================================================================
+# Comptime Evaluation Failures
+# =============================================================================
+
+[[case]]
+name = "comptime_cannot_use_runtime_variable"
+spec = ["4.13:4"]
+preview = "comptime"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    let x = 10;
+    comptime { x + 1 }
+}
+"""
+compile_fail = true
+error_contains = "cannot be known at compile time"
+
+[[case]]
+name = "comptime_cannot_call_function"
+spec = ["4.13:4"]
+preview = "comptime"
+preview_should_pass = true
+source = """
+fn add(a: i32, b: i32) -> i32 { a + b }
+fn main() -> i32 {
+    comptime { add(1, 2) }
+}
+"""
+compile_fail = true
+error_contains = "cannot be known at compile time"

--- a/crates/rue-spec/cases/modules/visibility.toml
+++ b/crates/rue-spec/cases/modules/visibility.toml
@@ -1,0 +1,132 @@
+[section]
+id = "modules.visibility"
+name = "Visibility"
+description = "Pub visibility modifier for functions, structs, and enums (Phase 1 of module system). Spec chapter pending ADR-0026 finalization."
+
+# =============================================================================
+# Public Functions
+# =============================================================================
+
+[[case]]
+name = "pub_fn_basic"
+preview = "modules"
+preview_should_pass = true
+description = "Basic pub function declaration is allowed with preview flag"
+source = """
+pub fn helper() -> i32 { 42 }
+fn main() -> i32 { helper() }
+"""
+exit_code = 42
+
+[[case]]
+name = "pub_fn_with_params"
+preview = "modules"
+preview_should_pass = true
+description = "Pub function with parameters"
+source = """
+pub fn add(a: i32, b: i32) -> i32 { a + b }
+fn main() -> i32 { add(20, 22) }
+"""
+exit_code = 42
+
+[[case]]
+name = "pub_fn_without_preview_error"
+description = "Pub function without preview flag gives helpful error"
+source = """
+pub fn helper() -> i32 { 42 }
+fn main() -> i32 { helper() }
+"""
+compile_fail = true
+error_contains = "preview"
+
+# =============================================================================
+# Public Structs
+# =============================================================================
+
+[[case]]
+name = "pub_struct_basic"
+preview = "modules"
+preview_should_pass = true
+description = "Basic pub struct declaration is allowed with preview flag"
+source = """
+pub struct Point { x: i32, y: i32 }
+fn main() -> i32 {
+    let p = Point { x: 10, y: 32 };
+    p.x + p.y
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "pub_struct_without_preview_error"
+description = "Pub struct without preview flag gives helpful error"
+source = """
+pub struct Point { x: i32, y: i32 }
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = "preview"
+
+# =============================================================================
+# Public Enums
+# =============================================================================
+
+[[case]]
+name = "pub_enum_basic"
+preview = "modules"
+preview_should_pass = true
+description = "Basic pub enum declaration is allowed with preview flag"
+source = """
+pub enum Color { Red, Green, Blue }
+fn main() -> i32 {
+    let c = Color::Red;
+    match c {
+        Color::Red => 42,
+        Color::Green => 0,
+        Color::Blue => 0,
+    }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "pub_enum_without_preview_error"
+description = "Pub enum without preview flag gives helpful error"
+source = """
+pub enum Status { Active, Inactive }
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = "preview"
+
+# =============================================================================
+# Mixed Visibility
+# =============================================================================
+
+[[case]]
+name = "mixed_pub_and_private"
+preview = "modules"
+preview_should_pass = true
+description = "Mix of public and private declarations"
+source = """
+pub fn public_fn() -> i32 { 10 }
+fn private_fn() -> i32 { 20 }
+
+pub struct PubPoint { x: i32 }
+struct PrivPoint { y: i32 }
+
+pub enum PubStatus { On, Off }
+enum PrivStatus { Active, Inactive }
+
+fn main() -> i32 {
+    let p1 = PubPoint { x: public_fn() };
+    let p2 = PrivPoint { y: private_fn() };
+    let s1 = PubStatus::On;
+    let s2 = PrivStatus::Active;
+    match s1 {
+        PubStatus::On => p1.x + p2.y + 12,
+        PubStatus::Off => 0,
+    }
+}
+"""
+exit_code = 42

--- a/docs/designs/0025-comptime.md
+++ b/docs/designs/0025-comptime.md
@@ -1,0 +1,483 @@
+---
+id: 0025
+title: Compile-Time Execution (comptime)
+status: proposal
+tags: [compiler, type-system, generics]
+feature-flag: comptime
+created: 2026-01-01
+accepted:
+implemented:
+spec-sections: []
+superseded-by:
+---
+
+# ADR-0025: Compile-Time Execution (comptime)
+
+## Status
+
+Proposal
+
+## Summary
+
+Introduce a unified compile-time execution model inspired by Zig, where `comptime` marks expressions and parameters that must be evaluated at compile time, and `type` becomes a first-class comptime-only value. This provides the foundation for generics while also enabling powerful compile-time computation as a feature in its own right.
+
+## Context
+
+Rue currently has basic constant expression evaluation (ADR-0003) that handles arithmetic on literals for compile-time bounds checking. However, this is limited:
+
+1. **No user-visible constant declarations**: Users can't define named compile-time constants
+2. **No compile-time functions**: Can't run arbitrary code at compile time
+3. **No generics**: No way to parameterize functions or types over other types
+4. **No type-level computation**: Can't compute types based on other types
+
+Other languages have approached this differently:
+
+- **Rust**: `const fn` with gradually expanding capabilities, separate generics syntax with `<T>`
+- **C++**: `constexpr`/`consteval` with template metaprogramming for generics
+- **Zig**: Unified `comptime` model where types are first-class values
+
+Zig's approach is elegant because it uses the **same syntax and semantics** for both compile-time computation and generics. A generic function is simply a function with comptime parameters. This reduces conceptual overhead and makes the language more orthogonal.
+
+### Why Zig's Model?
+
+1. **Unified mental model**: One concept (`comptime`) instead of multiple (const fn, generics, macros)
+2. **Types as values**: `type` is a comptime-only type, so `fn foo(comptime T: type)` is just a function that takes a type
+3. **Same syntax**: Comptime code looks like runtime code, just with `comptime` annotations
+4. **Powerful metaprogramming**: Compile-time loops, conditionals, and function calls enable sophisticated code generation
+
+## Decision
+
+### Core Concepts
+
+#### 1. The `comptime` Keyword
+
+`comptime` is a guarantee that an expression will be evaluated at compile time. If evaluation fails (e.g., due to runtime dependencies), it's a compile error.
+
+```rue
+// Comptime block - must evaluate at compile time
+const SIZE: i32 = comptime { 1024 * 1024 };
+
+// Comptime parameter - caller must provide a comptime-known value
+fn repeat(comptime n: i32, value: i32) -> i32 {
+    // n is known at compile time, so this loop can be unrolled
+    let mut sum = 0;
+    let mut i = 0;
+    while i < n {
+        sum = sum + value;
+        i = i + 1;
+    }
+    sum
+}
+```
+
+#### 2. The `type` Type
+
+`type` is a comptime-only type whose values are types themselves:
+
+```rue
+fn max(comptime T: type, a: T, b: T) -> T {
+    if a > b { a } else { b }
+}
+
+fn main() -> i32 {
+    max(i32, 10, 20)  // T = i32, returns 20
+}
+```
+
+The value `i32` has type `type`. Since `type` is comptime-only, it can never exist at runtime.
+
+#### 3. Comptime-Only Values
+
+Some values can only exist at compile time:
+
+| Type | Description |
+|------|-------------|
+| `type` | Type values (e.g., `i32`, `bool`, `MyStruct`) |
+| `comptime_int` | Arbitrary-precision integers (future) |
+| `comptime_float` | Arbitrary-precision floats (future) |
+
+Attempting to store these in a runtime variable is a compile error:
+
+```rue
+fn main() -> i32 {
+    let t: type = i32;  // ERROR: type 'type' cannot exist at runtime
+    0
+}
+```
+
+#### 4. Monomorphization
+
+When a function has comptime type parameters, each unique combination of comptime arguments creates a specialized version:
+
+```rue
+fn max(comptime T: type, a: T, b: T) -> T {
+    if a > b { a } else { b }
+}
+
+fn main() -> i32 {
+    let x = max(i32, 1, 2);   // Generates max__i32
+    let y = max(i64, 3, 4);   // Generates max__i64
+    x
+}
+```
+
+After monomorphization, AIR contains no generic functions - only concrete specialized versions.
+
+### Syntax
+
+#### Comptime Blocks
+
+```rue
+comptime { <expr> }
+```
+
+The expression inside must be evaluable at compile time. The result replaces the comptime block.
+
+#### Comptime Parameters
+
+```rue
+fn name(comptime param: Type, ...) -> ReturnType { ... }
+```
+
+Parameters marked `comptime` must be provided with comptime-known values at every call site.
+
+#### Const Items
+
+```rue
+const NAME: Type = <expr>;
+```
+
+The expression must be comptime-evaluable. If it's not obviously constant, use `comptime { }`:
+
+```rue
+const TABLE_SIZE: i32 = comptime { compute_size() };
+```
+
+#### Type Parameters
+
+```rue
+fn generic(comptime T: type, value: T) -> T { ... }
+```
+
+This is just a comptime parameter whose type is `type`.
+
+### Semantics
+
+#### Evaluation Order
+
+Comptime evaluation happens during semantic analysis (Sema), after parsing and before code generation:
+
+```
+Source → Lexer → Parser → RIR → Sema (comptime eval here) → AIR → Codegen
+```
+
+When Sema encounters a comptime context:
+1. It evaluates the expression using the comptime interpreter
+2. If successful, the result replaces the original expression
+3. If unsuccessful (runtime dependency), emit a compile error
+
+#### Comptime Context Propagation
+
+Inside a comptime context, everything is comptime:
+
+```rue
+comptime {
+    let x = 1 + 2;      // Comptime evaluation
+    let y = x * 3;      // Also comptime
+    foo(x, y)           // foo must be callable at comptime
+}
+```
+
+#### What Can Run at Comptime
+
+Initially (Phase 1-2):
+- Arithmetic operations
+- Comparisons
+- Logical operations
+- Variable bindings
+- Control flow (if/else, while, loops)
+- Function calls (to "pure" functions)
+
+Future extensions:
+- Struct/array construction
+- Pattern matching
+- More complex control flow
+
+#### What Cannot Run at Comptime
+
+- I/O operations
+- System calls
+- Accessing runtime memory
+- Calling functions with side effects
+- Operations that would panic (result in compile error instead)
+
+#### Error Handling
+
+Comptime errors are compile errors:
+
+```rue
+const X: i32 = comptime { 1 / 0 };  // Compile error: division by zero
+```
+
+### Type System Integration
+
+#### ConstValue Extension
+
+The existing `ConstValue` enum will be extended:
+
+```rust
+pub enum ConstValue {
+    Integer(i64),
+    Bool(bool),
+    Type(TypeId),      // NEW: For type values
+    Unit,              // NEW: For ()
+    // Future: Array, Struct, etc.
+}
+```
+
+#### Type as a Type
+
+A new `Type::ComptimeType` variant represents the `type` type:
+
+```rust
+pub enum Type {
+    // ... existing variants ...
+    ComptimeType,  // The type of types (e.g., `i32` has type `type`)
+}
+```
+
+#### Comptime Context Tracking
+
+Sema tracks whether it's in a comptime context:
+
+```rust
+struct Sema<'a> {
+    // ... existing fields ...
+    comptime_depth: u32,  // 0 = runtime, >0 = comptime
+}
+```
+
+Operations check this to know if they must be comptime-evaluable.
+
+### Monomorphization Strategy
+
+When Sema encounters a call to a generic function:
+
+1. **Evaluate comptime args**: All comptime arguments are evaluated to ConstValue
+2. **Generate key**: Create a unique key from (function_name, comptime_args)
+3. **Check cache**: If this specialization exists, use it
+4. **Specialize**: Otherwise, create a new specialized function:
+   - Clone the RIR function
+   - Substitute comptime parameters with their concrete values
+   - Analyze the specialized body
+   - Store in specialization cache
+5. **Emit call**: The call becomes a call to the specialized function
+
+### Anonymous Struct Types (Future)
+
+Comptime functions can return types, enabling patterns like:
+
+```rue
+fn Pair(comptime T: type, comptime U: type) -> type {
+    struct {
+        first: T,
+        second: U,
+    }
+}
+
+fn main() -> i32 {
+    let p: Pair(i32, bool) = Pair(i32, bool) { first: 42, second: true };
+    p.first
+}
+```
+
+This requires:
+- Anonymous struct type syntax
+- Comptime struct construction
+- Type equality based on structural equivalence
+
+This is deferred to Phase 4.
+
+## Implementation Phases
+
+Epic: rue-33lf
+
+### Phase 1: Comptime Expressions (rue-3xoq)
+
+**Goal**: `comptime { expr }` syntax with basic expression evaluation.
+
+- [ ] Add `comptime` keyword to lexer
+- [ ] Add `ComptimeBlock` AST/RIR node
+- [ ] Add comptime context tracking in Sema
+- [ ] Extend `try_evaluate_const()` to handle comptime blocks
+- [ ] Gate behind preview flag `comptime`
+- [ ] Add spec tests for comptime expressions
+
+**Deliverable**: Users can write `const X: i32 = comptime { 1 + 2 * 3 };`
+
+### Phase 2: Comptime Parameters (Value) (rue-ya9i)
+
+**Goal**: Functions can take comptime value parameters.
+
+- [ ] Add `comptime` parameter modifier to parser
+- [ ] Track comptime parameters in function signatures
+- [ ] Validate comptime args are comptime-known at call sites
+- [ ] Implement function specialization for comptime value params
+- [ ] Add spec tests
+
+**Deliverable**: Users can write `fn repeat(comptime n: i32, x: i32) -> i32`
+
+### Phase 3: Type Parameters (rue-fbwv)
+
+**Goal**: The `type` type and comptime type parameters.
+
+- [ ] Add `Type::ComptimeType` variant
+- [ ] Add `ConstValue::Type(TypeId)` variant
+- [ ] Parse `type` as a type name
+- [ ] Implement type parameter substitution in specialization
+- [ ] Add spec tests for generic functions
+
+**Deliverable**: Users can write `fn max(comptime T: type, a: T, b: T) -> T`
+
+### Phase 4: Comptime Type Construction (rue-ak9z)
+
+**Goal**: Comptime functions can construct and return types.
+
+- [ ] Anonymous struct type syntax
+- [ ] Comptime struct construction
+- [ ] Structural type equality
+- [ ] Add spec tests
+
+**Deliverable**: Users can write `fn Pair(comptime T: type) -> type { struct { ... } }`
+
+## Consequences
+
+### Positive
+
+- **Unified model**: One concept for const evaluation, metaprogramming, and generics
+- **Same syntax**: Comptime code uses normal Rue syntax, no special template language
+- **Incremental adoption**: Each phase adds value; Phase 1 is useful standalone
+- **Type safety**: Types are first-class values but still statically checked
+- **Zero runtime cost**: All comptime computation happens at compile time
+- **Foundation for stdlib**: Enables generic `Vec<T>`, `HashMap<K,V>`, etc.
+
+### Negative
+
+- **Compile time increase**: More work at compile time, especially with heavy monomorphization
+- **Code bloat**: Each specialization generates new code (mitigated by deduplication later)
+- **Complexity**: Sema becomes more complex with comptime interpreter
+- **Error messages**: Comptime errors can be confusing (which instantiation failed?)
+- **Learning curve**: `comptime` is a new concept for users from Rust/C++
+
+### Neutral
+
+- **Different from Rust**: Users expecting `<T>` syntax will need to learn the new model
+- **Supersedes ADR-0003**: The comptime infrastructure subsumes constant evaluation
+
+## Open Questions
+
+1. **Comptime variable declarations**: Should `comptime let x = ...` exist, or only const items?
+   - *Tentative answer*: Only const items initially. `comptime { let x = ... }` works inside blocks.
+
+2. **Comptime function annotation**: Should functions be explicitly marked `comptime fn`?
+   - *Tentative answer*: No. Any function callable at comptime can be, if all inputs are comptime-known.
+
+3. **Recursion limits**: How do we prevent infinite compile-time recursion?
+   - *Tentative answer*: Configurable recursion/iteration limits with reasonable defaults.
+
+4. **Comptime strings**: Should string literals be comptime values?
+   - *Tentative answer*: Defer to future work. Focus on numeric types and `type` first.
+
+5. **Trait/interface bounds**: How do we express "T must support +"?
+   - *Tentative answer*: Out of scope for this ADR. Will need a separate traits/interfaces design.
+
+## Future Work
+
+These are explicitly out of scope for this ADR:
+
+- **Traits/Interfaces**: Constraining type parameters (e.g., `T: Comparable`)
+- **Comptime allocations**: Allocating memory at compile time (like Zig's comptime allocator)
+- **Comptime I/O**: Reading files at compile time (`@embedFile` equivalent)
+- **Comptime reflection**: Introspecting types at compile time (`@typeInfo` equivalent)
+- **Comptime strings**: String manipulation at compile time
+- **Associated types**: Types defined in trait implementations
+- **Higher-kinded types**: Types parameterized over type constructors
+
+## References
+
+- [ADR-0003: Constant Expression Evaluation](0003-constant-evaluation.md) - Foundation this builds on
+- [Zig Language Reference: comptime](https://ziglang.org/documentation/master/#comptime) - Primary inspiration
+- [Zig's compile-time reflection](https://ziglang.org/documentation/master/#typeInfo) - Future direction
+- [Rust const generics](https://doc.rust-lang.org/reference/items/generics.html#const-generics) - Alternative approach
+- [C++ constexpr](https://en.cppreference.com/w/cpp/language/constexpr) - Another alternative
+
+## Appendix: Example Code
+
+### Phase 1: Comptime Expressions
+
+```rue
+// Compile-time arithmetic
+const BUFFER_SIZE: i32 = comptime { 4 * 1024 };
+const FLAGS: i32 = comptime { 1 | 2 | 4 };
+
+fn main() -> i32 {
+    // Can use comptime inline too
+    let x = comptime { 10 * 10 };
+    x + BUFFER_SIZE
+}
+```
+
+### Phase 2: Comptime Value Parameters
+
+```rue
+// Compile-time loop unrolling
+fn sum_n(comptime n: i32) -> i32 {
+    let mut total = 0;
+    let mut i = 0;
+    while i < n {
+        total = total + i;
+        i = i + 1;
+    }
+    total
+}
+
+fn main() -> i32 {
+    sum_n(5)  // Unrolled at compile time: 0+1+2+3+4 = 10
+}
+```
+
+### Phase 3: Generic Functions
+
+```rue
+fn swap(comptime T: type, a: T, b: T) -> (T, T) {
+    (b, a)
+}
+
+fn identity(comptime T: type, x: T) -> T {
+    x
+}
+
+fn main() -> i32 {
+    let (y, x) = swap(i32, 1, 2);
+    identity(i32, x + y)
+}
+```
+
+### Phase 4: Type Construction (Future)
+
+```rue
+fn Array(comptime T: type, comptime N: i32) -> type {
+    struct {
+        data: [T; N],
+        len: i32,
+    }
+}
+
+fn main() -> i32 {
+    let arr: Array(i32, 10) = Array(i32, 10) {
+        data: [0; 10],
+        len: 10,
+    };
+    arr.len
+}
+```

--- a/docs/designs/0026-module-system.md
+++ b/docs/designs/0026-module-system.md
@@ -1,0 +1,397 @@
+---
+id: 0026
+title: Module System
+status: proposal
+tags: [architecture, compiler, modules, scalability]
+feature-flag: modules
+created: 2026-01-01
+accepted:
+implemented:
+spec-sections: []
+superseded-by:
+---
+
+# ADR-0026: Module System
+
+## Status
+
+Proposal
+
+## Summary
+
+Introduce a module system for Rue that prioritizes fast compilation through lazy semantic analysis, uses a simple "file = struct" model inspired by Zig, and provides straightforward pub/private visibility. This design supersedes the flat namespace from ADR-0023 (multi-file compilation) while preserving forward compatibility with future package management.
+
+## Context
+
+### Current State
+
+ADR-0023 introduced multi-file compilation with a flat global namespace—all functions, structs, and enums are globally visible across files. This was explicitly a stepping stone:
+
+> "The UX is admittedly awkward (`rue a.rue b.rue c.rue -o out`), but this is a stepping stone, not the final design."
+
+We now need a proper module system that provides:
+1. **Namespacing** — Avoid symbol collisions as codebases grow
+2. **Encapsulation** — Hide implementation details
+3. **Fast compilation** — The primary design constraint
+
+### Design Goals
+
+1. **Compilation speed is paramount** — Inspired by Zig's lazy analysis approach
+2. **Simplicity over flexibility** — Avoid Rust's module system complexity
+3. **Files are the unit of organization** — No separate "module declaration" concept
+4. **Forward-compatible with packages** — Don't box out future package management
+
+### Research Summary
+
+We analyzed module systems from several languages:
+
+| Language | Key Insight |
+|----------|-------------|
+| **Zig** | Files are structs; lazy analysis skips unreferenced code; simple pub/private |
+| **Rust** | Explicit `mod`/`use` creates cognitive overhead; fine-grained visibility rarely needed |
+| **Hylo** | Intra-module visibility is automatic; `pub` only affects cross-module |
+| **Swift** | Multiple visibility levels add complexity without proportional benefit |
+| **Go** | Directory = package; implicit file discovery; simple and fast |
+
+**Key takeaways:**
+- Zig's lazy analysis enables dramatically faster builds by only analyzing referenced code
+- Rust's module system is the #2 complaint after borrow checking—too many concepts (`mod`, `use`, `pub use`, `extern crate`, visibility modifiers)
+- Simple pub/private (Zig) or pub/internal/private (Hylo) covers 99% of use cases
+
+## Decision
+
+### Core Principle: Files Are Structs
+
+Every `.rue` file is implicitly a struct. Importing a file returns a struct type containing all `pub` declarations from that file.
+
+```rue
+// math.rue
+pub fn add(a: i32, b: i32) -> i32 { a + b }
+pub fn sub(a: i32, b: i32) -> i32 { a - b }
+fn helper() -> i32 { 42 }  // private, not exported
+
+// main.rue
+const math = @import("math.rue");
+
+fn main() -> i32 {
+    math.add(1, 2)  // OK
+    // math.helper()  // Error: `helper` is private
+}
+```
+
+### Import Syntax
+
+Following Zig's model, `@import` is a builtin that returns a struct type containing all `pub` declarations from the imported file:
+
+```rue
+// @import returns a struct type
+const math = @import("math.rue");
+math.add(1, 2)
+
+// You can alias to any name
+const m = @import("math.rue");
+m.add(1, 2)
+
+// Access nested items directly
+const add = @import("math.rue").add;
+add(1, 2)
+```
+
+The key insight: `@import("foo.rue")` is equivalent to a struct containing the file's contents:
+
+```rue
+// If math.rue contains:
+pub fn add(a: i32, b: i32) -> i32 { a + b }
+pub fn sub(a: i32, b: i32) -> i32 { a - b }
+fn helper() -> i32 { 42 }  // private
+
+// Then @import("math.rue") returns something like:
+// struct {
+//     pub fn add(a: i32, b: i32) -> i32 { ... }
+//     pub fn sub(a: i32, b: i32) -> i32 { ... }
+//     // helper is not visible - it's private
+// }
+```
+
+**Resolution order for `@import("foo")`:**
+1. Local file `foo.rue` (simple file module)
+2. Local file `_foo.rue` with directory `foo/` (directory module)
+3. (Future) Dependency named `foo` in `rue.toml`
+
+### Directory Modules
+
+A directory becomes a module when it contains a `_` prefixed file with the same name:
+
+```
+src/
+  main.rue
+  math.rue           # const math = @import("math.rue");
+  _utils.rue         # const utils = @import("utils"); — module root for utils/
+  utils/
+    strings.rue      # Submodule
+    internal.rue     # Submodule
+```
+
+The `_utils.rue` file controls what the directory exports using Zig's `pub const` pattern for re-exports:
+
+```rue
+// _utils.rue — the module root for utils/
+
+// Re-export the entire strings module
+pub const strings = @import("utils/strings.rue");
+
+// Re-export a specific function from internal
+pub const helper = @import("utils/internal.rue").helper;
+
+// internal module itself is not re-exported, so users can't access
+// @import("utils").internal — they'd have to import it directly
+```
+
+Usage:
+
+```rue
+// main.rue
+const utils = @import("utils");
+
+// Access re-exported submodule
+utils.strings.format("hello")
+
+// Access re-exported function directly
+utils.helper()
+
+// Can also import submodules directly if needed
+const internal = @import("utils/internal.rue");
+```
+
+**Why `_` prefix?**
+1. **Sorts first** — In file listings, `_utils.rue` appears before `utils/`, making the module entry point immediately visible
+2. **Unambiguous** — `_foo.rue` is always a directory module root; `foo.rue` is always a standalone file module
+3. **No dual-file confusion** — Rust's `foo.rs` + `foo/` pattern requires remembering that both exist; here the `_` makes it explicit
+
+This follows matklad's suggestion from "Notes on Module System" for improving discoverability.
+
+**No `mod` declarations needed.** Unlike Rust, there's no need to write `mod strings;` to declare that `strings.rue` exists. The filesystem is the source of truth — if the file exists, it can be imported. Re-exports are explicit `pub const` bindings, following Zig's pattern.
+
+### Visibility: Simple pub/private
+
+Only two visibility levels:
+
+| Modifier | Meaning |
+|----------|---------|
+| `pub` | Visible to importers |
+| (none) | Private to this file |
+
+**Rationale:** Rust's `pub(crate)`, `pub(super)`, `pub(in path)` are rarely used and add cognitive overhead. If we later need package-level visibility, we can add `pub(pkg)` without breaking existing code.
+
+**Intra-directory visibility:** Files within the same directory can access each other's non-pub items. This matches Hylo's model where `pub` only affects cross-module (cross-directory) visibility.
+
+```rue
+// utils/strings.rue
+fn internal_helper() { ... }  // Private
+
+// utils/parser.rue
+use strings;
+fn parse() {
+    strings::internal_helper()  // OK - same directory
+}
+
+// main.rue
+use utils::strings;
+fn main() {
+    // strings::internal_helper()  // Error - different directory
+}
+```
+
+### Lazy Semantic Analysis
+
+**The key to fast compilation.** The compiler only analyzes code that is actually referenced from entry points.
+
+```rue
+// broken.rue
+pub fn works() -> i32 { 42 }
+pub fn broken() -> i32 { "not an int" }  // Type error!
+
+// main.rue
+use broken;
+fn main() -> i32 {
+    broken::works()  // Only this is analyzed
+    // broken::broken() is never called, so its error is NOT reported
+}
+```
+
+**Trade-off:** Errors in unreferenced code are silently ignored. This is the same trade-off Zig makes, and it's deliberate:
+- Faster builds (don't analyze unused code)
+- Smaller binaries (unused code isn't codegen'd)
+- IDE tooling may need separate "check all" mode
+
+**Implementation:** Semantic analysis starts at `main()` and follows references. Each declaration is analyzed at most once, with results cached.
+
+### Entry Points
+
+- A program must have exactly one `pub fn main()`
+- The file containing `main()` is the entry point for analysis
+- Libraries (future) will have different entry point rules
+
+### Standard Library
+
+The standard library is **not** implicitly imported (unlike Hylo). Users must explicitly import what they need:
+
+```rue
+use std::io;
+use std::collections::Vec;
+```
+
+**Rationale:** Explicit imports make dependencies clear and don't pollute the namespace. This also makes the prelude smaller and compilation faster.
+
+### Circular Imports
+
+Circular imports between files are **allowed** at the type level but not at the value level:
+
+```rue
+// a.rue
+use b;
+pub struct Foo { b: b::Bar }  // OK - type reference
+
+// b.rue
+use a;
+pub struct Bar { a: a::Foo }  // OK - type reference
+```
+
+```rue
+// a.rue
+use b;
+pub const X: i32 = b::Y + 1;  // Error - circular value dependency
+
+// b.rue
+use a;
+pub const Y: i32 = a::X + 1;  // Error - circular value dependency
+```
+
+The compiler detects cycles during lazy analysis and reports clear errors.
+
+### Relationship to Multi-File Compilation (ADR-0023)
+
+This ADR **supersedes** the flat namespace from ADR-0023. The compilation model remains similar:
+
+```
+┌─────────────┐     ┌─────────────┐     ┌─────────────┐
+│  main.rue   │     │  math.rue   │     │  utils/     │
+└──────┬──────┘     └──────┬──────┘     └──────┬──────┘
+       │                   │                   │
+       ▼                   ▼                   ▼
+┌─────────────────────────────────────────────────────┐
+│              Lazy Semantic Analysis                  │
+│  (starts at main, follows imports on demand)        │
+└─────────────────────────────────────────────────────┘
+                           │
+                           ▼
+                    ┌─────────────┐
+                    │   Codegen   │
+                    └─────────────┘
+```
+
+**Key change:** Instead of merging all symbols into a flat namespace, we now:
+1. Start analysis at `main()`
+2. When encountering `use foo`, lazily analyze `foo.rue`
+3. Only analyze declarations that are actually referenced
+
+### Future: Package Management
+
+This module system is designed to be forward-compatible with packages. A future `rue.toml` would map package names to sources:
+
+```toml
+# rue.toml (future)
+[dependencies]
+http = { url = "https://...", hash = "sha256:..." }
+json = { path = "../json-lib" }
+```
+
+The resolution order becomes:
+1. Local file `foo.rue` (simple file module)
+2. Local file `_foo.rue` with `foo/` directory (directory module)
+3. Dependency `foo` from `rue.toml`
+
+The import syntax (`use foo;`) remains unchanged—the package manager just adds another resolution step.
+
+## Implementation Phases
+
+### Phase 1: Basic Module Imports
+
+**Goal:** `use foo;` imports `foo.rue` from the same directory.
+
+**Tasks:**
+- Add `use` statement to parser
+- Implement single-file module resolution
+- Update sema to handle qualified paths (`foo::bar`)
+- Add `pub` visibility checking
+
+### Phase 2: Directory Modules
+
+**Goal:** `use foo;` can import `_foo.rue` which has submodules in `foo/`.
+
+**Tasks:**
+- Implement directory module resolution (`_foo.rue` + `foo/` pattern)
+- Implement re-exports (`pub use`)
+- Intra-directory visibility rules
+
+### Phase 3: Lazy Analysis
+
+**Goal:** Only analyze referenced code.
+
+**Tasks:**
+- Refactor sema to start from entry points
+- Implement on-demand declaration analysis
+- Add caching for analyzed declarations
+- Cycle detection for circular imports
+
+### Phase 4: Standard Library Structure
+
+**Goal:** Organize std as proper modules.
+
+**Tasks:**
+- Structure `std` as a module tree
+- Implement `use std::*` syntax
+- Document standard library modules
+
+## Consequences
+
+### Positive
+
+- **Fast compilation** — Lazy analysis skips unreferenced code
+- **Simple mental model** — Files are structs, `pub` or private
+- **No boilerplate** — No `mod` declarations, no `extern crate`
+- **Forward-compatible** — Package system can layer on top
+
+### Negative
+
+- **Silent errors in unused code** — Trade-off for speed
+- **Less encapsulation than Rust** — No `pub(crate)` equivalent (yet)
+- **Different from Rust** — Users familiar with Rust need to unlearn some habits
+
+### Neutral
+
+- **Directory structure matters** — File layout determines module structure
+- **No implicit prelude** — More explicit, but more typing for common imports
+
+## Open Questions
+
+1. **IDE support for lazy analysis** — Should we provide a `rue check --all` mode that analyzes everything regardless of reachability? (Not needed immediately, but maybe someday.)
+
+## Future Work
+
+- **Package management** — `rue.toml`, dependency resolution, content-addressed packages
+- **Package visibility** — `pub(pkg)` for package-internal APIs if needed
+- **Incremental compilation** — Build on lazy analysis for file-level caching
+- **Conditional compilation** — `#[cfg(...)]` attributes for platform-specific code
+
+## References
+
+- [ADR-0023: Multi-File Compilation](0023-multi-file-compilation.md) — Superseded flat namespace
+- [ADR-0025: Comptime](0025-comptime.md) — Related compile-time evaluation
+- [Notes on Module System](https://matklad.github.io/2021/11/27/notes-on-module-system.html) — matklad's analysis of module system design principles (key inspiration for filesystem-based modules, no `mod` declarations)
+- [Zig Module System](https://ziglang.org/learn/build-system/) — "Files are structs" inspiration
+- [Zig Sema: Lazy Analysis](https://mitchellh.com/zig/sema) — Mitchell Hashimoto's explanation
+- [Zig and Rust Comparison](https://matklad.github.io/2023/03/26/zig-and-rust.html) — matklad's analysis
+- [Rust Module System Criticism](https://without.boats/blog/the-rust-module-system-is-too-confusing/) — What to avoid
+- [Hylo Modules](https://docs.hylo-lang.org/language-tour/modules) — Intra-module visibility inspiration
+`


### PR DESCRIPTION
## Summary

This implements Phase 1 of ADR-0026 (Module System), enabling the `pub` keyword for visibility modifiers on functions, structs, and enums. The feature is gated behind `--preview modules`.

**Changes:**
- Add `Pub` token to lexer (rue-lexer)
- Add `Visibility` enum with `Private`/`Public` variants (rue-parser)
- Parse optional `pub` before fn/struct/enum declarations
- Add `is_pub` field to `FnDecl`, `StructDecl`, `EnumDecl` in RIR
- Add preview gate in sema (requires `--preview modules`)
- Add spec tests for pub visibility

**Test cases:**
- `pub fn` parses and compiles with preview flag
- `pub struct` parses and compiles with preview flag
- `pub enum` parses and compiles with preview flag
- Without `--preview modules`, `pub` gives helpful error
- Mixed public and private declarations work correctly

## Test plan

- [x] All unit tests pass
- [x] All spec tests pass (1194 tests)
- [x] All UI tests pass (38 tests)
- [x] Traceability check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)